### PR TITLE
Move metadata below title, fixes #68

### DIFF
--- a/_includes/posts.html
+++ b/_includes/posts.html
@@ -9,8 +9,8 @@
       <div class="podcast-container">
         <i class="blog-icon podcast"></i>
       </div>
+      <h1 class="h3"><a class="title" href=""></a></h1>
       <p class="post-info"></p>
-	    <h1 class="h3"><a class="title" href=""></a></h1>
     </div>
     <div class="clearfix"></div>
 


### PR DESCRIPTION
This should move the metadata below the title like so:

![screen shot 2015-07-01 at 3 33 50 pm](https://cloud.githubusercontent.com/assets/5162342/8465341/985264e4-2006-11e5-88fd-525f5aba797f.png)

You might consider playing with the spacing there a little bit.
