### PR TITLE
Fix blockquote formatting in many posts

### DIFF
--- a/_posts/2008-05-05-now-licensed-under-creative-commons.markdown
+++ b/_posts/2008-05-05-now-licensed-under-creative-commons.markdown
@@ -20,7 +20,7 @@ The Creative Commons site defines [four main clauses](http://creativecommons.org
 
 
 
-<blockquote>
+>
 
 > 
 > ![Attribution](/images/wordpress/cc-attrib.png) **Attribution**
@@ -73,9 +73,9 @@ You let others copy, distribute, display, and perform only verbatim copies of yo
 > 
 > 
 You allow others to distribute derivative works only under a license identical to the license that governs your work.
-> 
-> 
-</blockquote>
+>
+>
+
 
 
 

--- a/_posts/2008-06-20-safe-html-and-xss.markdown
+++ b/_posts/2008-06-20-safe-html-and-xss.markdown
@@ -44,7 +44,7 @@ That's [cross-site-scripting (XSS)](http://en.wikipedia.org/wiki/Cross-site_scri
 
 
 <blockquote>
-In recent years XSS surpassed buffer overflows to become the most common of all publicly reported security vulnerabilities. [ed: [the last time I wrote about this](http://www.codinghorror.com/blog/archives/000841.html), in early 2007, buffer overflows were more common.] Likely at least 70% of websites are open to XSS attacks on their users. Site administrators rarely fix XSS problems and, when they do, the hole is likely to have been open for more than a month and a half. In general, cross-site scripting holes can be seen as vulnerabilities present in web pages which allow attackers to bypass security mechanisms. By finding clever ways of injecting malicious scripts into web pages, an attacker can gain elevated access privileges to sensitive page content, session cookies, and a variety of other objects.
+In recent years XSS surpassed buffer overflows to become the most common of all publicly reported security vulnerabilities. [ed: <a href="http://www.codinghorror.com/blog/archives/000841.html">the last time I wrote about this</a>, in early 2007, buffer overflows were more common.] Likely at least 70% of websites are open to XSS attacks on their users. Site administrators rarely fix XSS problems and, when they do, the hole is likely to have been open for more than a month and a half. In general, cross-site scripting holes can be seen as vulnerabilities present in web pages which allow attackers to bypass security mechanisms. By finding clever ways of injecting malicious scripts into web pages, an attacker can gain elevated access privileges to sensitive page content, session cookies, and a variety of other objects.
 </blockquote>
 
 

--- a/_posts/2008-06-21-a-strangely-familiar-error.markdown
+++ b/_posts/2008-06-21-a-strangely-familiar-error.markdown
@@ -29,7 +29,7 @@ Ah yes, [the elusive stack overflow](http://en.wikipedia.org/wiki/Stack_overflow
 
 
 <blockquote>
-In software, a stack overflow occurs when too much memory is used on the [call stack](http://en.wikipedia.org/wiki/Call_stack). In many programming languages the call stack contains a limited amount of memory, usually determined at the start of the program. The size of the call stack depends on many factors, including the programming language, machine architecture, multi-threading, and amount of available memory. When too much memory is used on the call stack the stack is said to overflow; typically resulting in a program crash. This class of software bug is usually caused by one of two types of programming errors: **infinite recursion**, or **very large stack variables**.
+In software, a stack overflow occurs when too much memory is used on the <a href="http://en.wikipedia.org/wiki/Call_stack">call stack</a>. In many programming languages the call stack contains a limited amount of memory, usually determined at the start of the program. The size of the call stack depends on many factors, including the programming language, machine architecture, multi-threading, and amount of available memory. When too much memory is used on the call stack the stack is said to overflow; typically resulting in a program crash. This class of software bug is usually caused by one of two types of programming errors: <strong>infinite recursion</strong>, or <strong>very large stack variables</strong>.
 </blockquote>
 
 

--- a/_posts/2008-06-25-three-markdown-gotcha.markdown
+++ b/_posts/2008-06-25-three-markdown-gotcha.markdown
@@ -76,7 +76,7 @@ I started to wonder if there were other edge conditions in advanced Markdown syn
 
 
 
-<blockquote>
+>
 **1) Markdown's single biggest flaw is its intra-word emphasis.**
 
 > 
@@ -215,10 +215,9 @@ I think this is a symptom of Markdown's being designed for blog posts.  You can 
 > 
 In my mind, this last one is huge.  If we allowed Markdown within block-level HTML, we could write a non-lossy version of [html2text](http://www.aaronsw.com/2002/html2text/) and make my dream of Markdown as a transient editing format a reality.
 
-> 
-> 
-Oh, also?  The HTML parser is pretty broken, so what gets recognized as a complete block of HTML can sometimes be surprising.  But Showdown uses an older, even-more-broken algorithm than the latest Markdown.pl beta, so I probably shouldn't point fingers.
-</blockquote>
+>
+> Oh, also?  The HTML parser is pretty broken, so what gets recognized as a complete block of HTML can sometimes be surprising.  But Showdown uses an older, even-more-broken algorithm than the latest Markdown.pl beta, so I probably shouldn't point fingers.
+
 
 
 

--- a/_posts/2008-10-06-solving-the-fastest-gun-in-the-west-problem.markdown
+++ b/_posts/2008-10-06-solving-the-fastest-gun-in-the-west-problem.markdown
@@ -20,7 +20,7 @@ Some Stack Overflow users are concerned about what they call [the "Fastest Gun i
 
 
 
-<blockquote>
+>
 Each question's answers are sorted by descending score and then descending time of posting. **This means that if a person sits down and answers a question in a long, thorough way, going through every nook and cranny, once they post their answer, it will already be one of about seven different ones, some of which have already been upmodded.** This wouldn't be a problem if those answers were as thorough as the one this guy's posting, but they usually aren't. Some of them are downright wrong, some aren't even answers to the question asked because their poster didn't bother to read the question all the way through.
 
 > 
@@ -30,7 +30,7 @@ This causes a problem I like to call SO's Fastest Gun in the West Problem.
 > 
 > 
 I've come to a point where I'd rather just send a short, simple, correct explanation, than to go and do some proper research, write a whole blog post about it or even make sure the code I post even compiles, just so it will be noticed, as opposed to the incorrect ones.
-</blockquote>
+
 
 
 
@@ -42,7 +42,7 @@ A number of solutions were proposed, but I believe many of them were worse than 
 
 
 
-<blockquote>
+>
 **I do NOT want to, in any way, discourage the quick and dirty answer.**
 
 > 
@@ -52,7 +52,7 @@ I've asked questions that have received an immediate answer with enough informat
 > 
 > 
 This is extraordinarily helpful - I know I can post something on here, day or night, and get an answer within minutes, often seconds, that will be better than searching through books, online, etc, even though it's a throw-away post that took someone 35 seconds, who may have only answered for the reputation. If it's at all helpful, I upvote it.
-</blockquote>
+
 
 
 

--- a/_posts/2008-10-12-a-question-about-questions.markdown
+++ b/_posts/2008-10-12-a-question-about-questions.markdown
@@ -20,47 +20,21 @@ tags:
 
 
 
-<blockquote>
-                **What kind of questions can I ask here?**
-            
-> 
-> 
-                Programming questions, of course! As long as your question is:
-> 
-> 
-            
-> 
-> 
-                
+> **What kind of questions can I ask here?**
+>
+> Programming questions, of course! As long as your question is:
+>
 >   * detailed and specific
-> 
-                
 >   * written clearly and simply
-> 
-                
 >   * of interest to at least one other programmer somewhere
-> 
-            
-            
-> 
-> 
-                ... it is welcome here. No question is too trivial or too "newbie". Oh yes, and it should be about **programming**. You know, with a computer.
-> 
-> 
-            
-> 
-> 
-                Do look around to see if your question has already been asked (and maybe even answered!) _before_ you ask. However, as long as you've looked, if you end up asking a question that has been asked before, that is OK and deliberately allowed. Other users will hopefully edit in links to related or similar questions to help future visitors find their way.
-            
-> 
-> 
-            
-> 
-> 
-                It's also perfectly fine to ask and answer your own programming question, but pretend you're on [Jeopardy](http://en.wikipedia.org/wiki/Jeopardy!): phrase it in the form of a question.
-> 
-> 
-</blockquote>
+>
+> ... it is welcome here. No question is too trivial or too "newbie". Oh yes, and it should be about **programming**. You know, with a computer.
+>
+>
+> Do look around to see if your question has already been asked (and maybe even answered!) _before_ you ask. However, as long as you've looked, if you end up asking a question that has been asked before, that is OK and deliberately allowed. Other users will hopefully edit in links to related or similar questions to help future visitors find their way.
+>
+> It's also perfectly fine to ask and answer your own programming question, but pretend you're on [Jeopardy](http://en.wikipedia.org/wiki/Jeopardy!): phrase it in the form of a question.
+
 
 
 

--- a/_posts/2008-10-13-tags-and-tags-or-tags.markdown
+++ b/_posts/2008-10-13-tags-and-tags-or-tags.markdown
@@ -36,13 +36,13 @@ This isn't exactly new; you could always do this manually in the URL by space de
 
 
 
-<blockquote>
+>
 Show me all the questions tagged _both_ "python" **AND** "django"
 
 > 
 > 
 [http://stackoverflow.com/questions/tagged/python django](http://stackoverflow.com/questions/tagged/python django)
-</blockquote>
+
 
 
 
@@ -62,13 +62,13 @@ But maybe that's too specific for your tastes. Now you use **the new or pseudo t
 
 
 
-<blockquote>
+>
 Show me all the questions tagged _either_ "python" **OR** "django"
 
 > 
 > 
 [http://stackoverflow.com/questions/tagged/python or django](http://stackoverflow.com/questions/tagged/python or django)
-</blockquote>
+
 
 
 
@@ -84,13 +84,13 @@ We also support **NOT** if you prefix the tag with a dash, like so:
 
 
 
-<blockquote>
+>
 Show me all the questions tagged "python" **BUT NOT** tagged "django"
 
 > 
 > 
 [http://stackoverflow.com/questions/tagged/python -django](http://stackoverflow.com/questions/tagged/python -django)
-</blockquote>
+
 
 
 

--- a/_posts/2008-10-18-stack-overflow-on-hanselminutes.markdown
+++ b/_posts/2008-10-18-stack-overflow-on-hanselminutes.markdown
@@ -19,7 +19,7 @@ Geoff, Jarrod and I recently [recorded an episode of Hanselminutes](http://www.h
 
 
 
-<blockquote>
+>
 
 > 
 > **StackOverflow uses ASP.NET MVC - Jeff Atwood and his technical team**
@@ -34,7 +34,7 @@ Geoff, Jarrod and I recently [recorded an episode of Hanselminutes](http://www.h
 > 
 > 
 [Listen or download](http://www.hanselminutes.com/default.aspx?showID=152)
-</blockquote>
+
 
 
 

--- a/_posts/2008-10-23-stack-overflow-openid-case-study.markdown
+++ b/_posts/2008-10-23-stack-overflow-openid-case-study.markdown
@@ -20,7 +20,7 @@ tags:
 
 
 
-<blockquote>
+>
 Stack Overflow, much like Wikipedia, lets anyone edit anything – but unlike Wikipedia, we require users to earn a certain number of votes from other users before the system trusts them (we call this "reputation"). The concept of identity and logins is an essential part of how our site works.
 
 > 
@@ -34,7 +34,7 @@ With OpenID, we didn't have to write any login code, nor do we have to store use
 > 
 > 
 We were encouraged to use OpenID because our audience is fairly technical, and OpenID is quite common among technical bloggers and frequent blog participants, our early adopters. Also, there's a rich ecosystem of third party OpenID providers, not to mention Yahoo, AOL, Google, Sun, and soon MySpace.
-</blockquote>
+
 
 
 

--- a/_posts/2008-11-01-sql-2008-full-text-search-problems.markdown
+++ b/_posts/2008-11-01-sql-2008-full-text-search-problems.markdown
@@ -19,7 +19,7 @@ You may have noticed that things have been less responsive than usual on stackov
 
 
 
-<blockquote>
+>
 **Before 2008, full text search wasn't inside the database - it wasn't subject to things like transactions.**  Heck, it was more like Lucene where it lived outside on its own.  Now, it's stored inside data files and it's subject to transactions.  From what im hearing, blocking and locking is a completely new issue in 2008 FTS.  There's a big overhead involved with making it subject to transactions.
 
 > 
@@ -29,7 +29,7 @@ In most environments, you don't see full text being used for transactions.  At S
 > 
 > 
 If you do a full text search on Revisions and you include a common keyword like, say, SQL, you're going to match tens of thousands of records.  When I look at the query plans for these, I'm seeing 50-100k reads.  Doing that inside a table that's also getting heavy inserts - boom, transactional disaster.
-</blockquote>
+
 
 
 

--- a/_posts/2008-11-25-stack-overflow-is-you.markdown
+++ b/_posts/2008-11-25-stack-overflow-is-you.markdown
@@ -27,7 +27,7 @@ Apparently this "question" is.. somewhat controversial; as of now it has [31 rev
 
 
 
-<blockquote>
+>
 These are written in the third person so as not to disrupt the style of the thing. But hey, as we all know, Jon Skeet can make 1 == 3 anyway, so it makes no difference.
 
 > 
@@ -48,7 +48,7 @@ These are written in the third person so as not to disrupt the style of the thin
 
 >   * Users don't mark Jon Skeet's answers as accepted. The universe accepts them out of a sense of truth and justice.
 
-</blockquote>
+
 
 
 

--- a/_posts/2008-12-27-new-uservoice-moderator.markdown
+++ b/_posts/2008-12-27-new-uservoice-moderator.markdown
@@ -32,9 +32,9 @@ I wasn't kidding when I said this in the [Stack Overflow FAQ](http://stackoverfl
 
 
 
-<blockquote>
-At the high end of this reputation spectrum there is little difference between users with high reputation and moderators. That is very much intentional. **We don't run Stack Overflow. The community does.** 
-</blockquote>
+>
+At the high end of this reputation spectrum there is little difference between users with high reputation and moderators. That is very much intentional. **We don't run Stack Overflow. The community does.**
+
 
 
 
@@ -46,7 +46,7 @@ These two guys have gone _far_ out of their way to help other users on UserVoice
 
 
 
-<blockquote>
+>
 _adjunct_ (adjective)
 
 > 
@@ -56,7 +56,7 @@ _adjunct_ (adjective)
 
 >   2. Attached to a faculty or staff in a temporary or auxiliary capacity: an adjunct professor of history.
 
-</blockquote>
+
 
 
 

--- a/_posts/2008-12-28-reverse-engineering-the-wmd-editor.markdown
+++ b/_posts/2008-12-28-reverse-engineering-the-wmd-editor.markdown
@@ -62,7 +62,7 @@ Chris adds the following comments:
 
 
 
-<blockquote>
+>
 1. How will we coordinate the changes? Do we want to have a forum where people can post links to their repositories? (My repository is writable by me only -- but Git being a distributed VCS, this is not a problem, people just clone their own.) Or do you prefer to have a central repository that everyone checks into? In this case, I'm happy to check things into it -- or you can import it from my repository.
 
 > 
@@ -72,7 +72,7 @@ Chris adds the following comments:
 > 
 > 
 I'll try to get more changes checked in periodically, but I still have a ton of projects to clear, so getting the ball rolling with other coders would probably be a good idea.
-</blockquote>
+
 
 
 

--- a/_posts/2008-12-31-i-move-to-close-this-question.markdown
+++ b/_posts/2008-12-31-i-move-to-close-this-question.markdown
@@ -29,9 +29,9 @@ I had a long email exchange with an avid Stack Overflow user, [Mike Stone](http:
 
 
 
-<blockquote>
+>
 Visit any online forum and you'll find lots of locked threads. Closing is equivalent to locking a thread. **Would you really argue that every online bulletin board should allow any topic whatsoever to be opened and discussed?** If so then maybe Stack Overflow is not the place for you, because that is definitely not the intent. Based on all the data I've seen, closing is working. So is voting. They complement each other!
-</blockquote>
+
 
 
 

--- a/_posts/2009-01-24-adventures-in-delclusionism.markdown
+++ b/_posts/2009-01-24-adventures-in-delclusionism.markdown
@@ -20,13 +20,11 @@ In Wikipedia, there are two opposing camps: [the inclusionists and the deletioni
 
 
 
-<blockquote>
-**Inclusionists** believe that there should be no constraints on the breadth of the encyclopedia - that Wikipedia should include any entry that any contributor wants to submit. An article on a small-town elementary school is no less worthy for inclusion than an article on Stanford University.
+> **Inclusionists** believe that there should be no constraints on the breadth of the encyclopedia - that Wikipedia should include any entry that any contributor wants to submit. An article on a small-town elementary school is no less worthy for inclusion than an article on Stanford University.
 
 > 
 > 
 **Deletionists** believe in weeding out entries that they view as trivial or otherwise inappropriate for a serious encyclopedia.
-</blockquote>
 
 
 
@@ -78,8 +76,7 @@ But let me share with you a thoughtful email I received from Christian Nunciato 
 
 
 
-<blockquote>
-On to my question.  I realize users have the ability to delete their own questions, which does seem right and good on the surface of things, but I have to say, it's a shame when some of us put such time and consideration into submitting thoughtful and complete answers, only to have the questions removed from the site inexplicably.  I'm writing in reference specifically to this one:
+> On to my question.  I realize users have the ability to delete their own questions, which does seem right and good on the surface of things, but I have to say, it's a shame when some of us put such time and consideration into submitting thoughtful and complete answers, only to have the questions removed from the site inexplicably.  I'm writing in reference specifically to this one:
 
 > 
 > 
@@ -89,10 +86,9 @@ On to my question.  I realize users have the ability to delete their own questio
 > 
 ... which I thought was an excellent question, and one other site users might ultimately benefit from; it digs a bit into the arcana of the language, and it's interesting stuff for those looking to deepen their understanding.  For some reason, though, it looks like the OP chose to take it down, which is a shame, because I personally spent a good deal of time drafting a submission for it, one that was upvoted and appeared to fix the user's problem and then some.
 
-> 
-> 
-I'm not asking for anything, though -- I just wanted to share that it's mildly discouraging to have put such work into something, in an attempt to contribute to the community, only to have the product taken down inexplicably and without recourse.  While the knowledge of having written it stays with me, which is great, it doesn't get out into the world, and it'll also make me think twice about spending as much time next time -- something that, as site owners, you might want to be aware of.  
-</blockquote>
+>
+>
+I'm not asking for anything, though -- I just wanted to share that it's mildly discouraging to have put such work into something, in an attempt to contribute to the community, only to have the product taken down inexplicably and without recourse.  While the knowledge of having written it stays with me, which is great, it doesn't get out into the world, and it'll also make me think twice about spending as much time next time -- something that, as site owners, you might want to be aware of.
 
 
 

--- a/_posts/2009-01-25-new-stack-overflow-servers-ready.markdown
+++ b/_posts/2009-01-25-new-stack-overflow-servers-ready.markdown
@@ -182,9 +182,9 @@ I also did a quick run of [SQLIOSim](http://support.microsoft.com/kb/231619), wh
 
 
 
-<blockquote>
+>
 **SQLIOSim will generate sufficient IO requests to overwhelm almost any disk subsystem.** The long IO message from the simulator are normal. Although this does tell you that at some point the disks won't keep up.
-</blockquote>
+
 
 
 

--- a/_posts/2009-01-27-reputation-bounty-for-unanswered-questions.markdown
+++ b/_posts/2009-01-27-reputation-bounty-for-unanswered-questions.markdown
@@ -24,9 +24,9 @@ If so, you're not alone. As Corey Trager noted [in a blog comment](http://ifdefi
 
 
 
-<blockquote>
+>
 Speaking for myself, you don't have to reward me for ASKING questions on Stackoverflow: Getting an answer is enough of a reward in itself. **Just do whatever you can to keep the answer-ers motivated.**
-</blockquote>
+
 
 
 

--- a/_posts/2009-02-08-new-datacenter-migration.markdown
+++ b/_posts/2009-02-08-new-datacenter-migration.markdown
@@ -48,13 +48,13 @@ Note that we have moved a bit further to the west coast of the USA in this migra
 
 
 
-<blockquote>
+>
  "There's nothing you can do about latency," says John Romero, referring to physical restraints that slow down network play. "It's inherent in the system."
 
 > 
 > 
 "Yeah," says John Carmack wistfully, "**the speed of light sucks**." 
-</blockquote>
+
 
 
 

--- a/_posts/2009-03-04-the-great-edit-wars.markdown
+++ b/_posts/2009-03-04-the-great-edit-wars.markdown
@@ -28,7 +28,7 @@ We're not exactly like wikipedia, because we are a hybrid system, but it's worth
 
 
 
-<blockquote>
+>
 Edit warring is the confrontational use of edits to win a content dispute. Administrators often must make a judgment call to identify edit warring when cooling disputes. Administrators currently use several measures to determine if a user is edit warring.
 
 > 
@@ -42,7 +42,7 @@ Edit warring is different from a bold, revert, discuss (BRD) cycle. Reverting va
 > 
 > 
 Edit warring is a behavior, not a simple measure of the number of reverts on a single page in a specific period of time.
-</blockquote>
+
 
 
 
@@ -54,13 +54,13 @@ And then there's the list of [the lamest Wikipedia Edit Wars](http://en.wikipedi
 
 
 
-<blockquote>
+>
 [Pavlova (food)](http://en.wikipedia.org/wiki/Pavlova_(food))
 
 > 
 > 
 Not the dancer, but rather the tasty antipodean dessert, which was invented in Australia[[4]](http://en.wikipedia.org/w/index.php?title=Pavlova_%28food%29&diff=48848026&oldid=48838557), New Zealand [[5]](http://en.wikipedia.org/w/index.php?title=Pavlova_%28food%29&diff=next&oldid=57435397), Australia[[6]](http://en.wikipedia.org/w/index.php?title=Pavlova_%28food%29&diff=next&oldid=51738981), [[7]](http://en.wikipedia.org/w/index.php?title=Pavlova_%28food%29&diff=next&oldid=66646396), [[8]](http://en.wikipedia.org/w/index.php?title=Pavlova_%28food%29&diff=next&oldid=74867687), New Zealand [[9]](http://en.wikipedia.org/w/index.php?title=Pavlova_%28food%29&diff=next&oldid=57435397), [Rabbit Season](http://en.wikipedia.org/wiki/Rabbit_Fire), Duck Season, fire!
-</blockquote>
+
 
 
 

--- a/_posts/2009-03-06-new-10k-rep-tools-now-available.markdown
+++ b/_posts/2009-03-06-new-10k-rep-tools-now-available.markdown
@@ -19,7 +19,7 @@ Those 10,000 reputation tools I promised, [lo those many moons ago?](http://blog
 
 
 
-<blockquote>
+>
 
 > 
 > Congratulations on achieving 10,000 reputation!
@@ -66,7 +66,6 @@ Those 10,000 reputation tools I promised, [lo those many moons ago?](http://blog
 >   * recent questions with most vote velocity
 > 
 
-</blockquote>
 
 
 
@@ -86,9 +85,9 @@ These are **the same tools we use** to keep an eye on the system and make sure n
 
 
 
-<blockquote>
 We don't run Stack Overflow. _You_ do. Stack Overflow is **collaboratively built and maintained by your fellow programmers**. Once the system learns to trust you, you'll be able to edit anything, much like Wikipedia. With your help, we can build good answers to every imaginable programming question together. No matter what programming language you use, or what operating system you call home -- better programming is our goal. 
-</blockquote>
+>
+
 
 
 

--- a/_posts/2009-03-09-the-value-of-downvoting-or-how-hacker-news-gets-it-wrong.markdown
+++ b/_posts/2009-03-09-the-value-of-downvoting-or-how-hacker-news-gets-it-wrong.markdown
@@ -18,11 +18,11 @@ Paul Graham's [Hacker News](http://news.ycombinator.com/) is a great website to 
 It is true that **discussion on Hacker News is more serious and less incendiary than the wild-west anything goes of programming.reddit.com**. I've seen this firsthand, on blog articles I've written that have been posted to both sites. In [What I've Learned from Hacker News](http://www.paulgraham.com/hackernews.html), Paul explains:
 
 
-<blockquote>It's pretty clear now that the broken windows theory applies to community sites as well. The theory is that minor forms of bad behavior encourage worse ones: that a neighborhood with lots of graffiti and broken windows becomes one where robberies occur. I was living in New York when Giuliani introduced the reforms that made the broken windows theory famous, and the transformation was miraculous. And I was a Reddit user when the opposite happened there, and the transformation was equally dramatic.
+> It's pretty clear now that the broken windows theory applies to community sites as well. The theory is that minor forms of bad behavior encourage worse ones: that a neighborhood with lots of graffiti and broken windows becomes one where robberies occur. I was living in New York when Giuliani introduced the reforms that made the broken windows theory famous, and the transformation was miraculous. And I was a Reddit user when the opposite happened there, and the transformation was equally dramatic.
 
-I'm not criticizing Steve and Alexis. What happened to Reddit didn't happen out of neglect. From the start they had a policy of censoring nothing except spam. Plus Reddit had different goals from Hacker News. Reddit was a startup, not a side project; its goal was to grow as fast as possible. Combine rapid growth and zero censorship, and the result is a free for all. But I don't think they'd do much differently if they were doing it again. Measured by traffic, Reddit is much more successful than Hacker News.
+> I'm not criticizing Steve and Alexis. What happened to Reddit didn't happen out of neglect. From the start they had a policy of censoring nothing except spam. Plus Reddit had different goals from Hacker News. Reddit was a startup, not a side project; its goal was to grow as fast as possible. Combine rapid growth and zero censorship, and the result is a free for all. But I don't think they'd do much differently if they were doing it again. Measured by traffic, Reddit is much more successful than Hacker News.
 
-But what happened to Reddit won't inevitably happen to HN.</blockquote>
+> But what happened to Reddit won't inevitably happen to HN.
 
 
 It's a good read for anyone interested in building communities online. As you might imagine, I read it with particular interest since we've been running a full blown (and far larger than I would have predicted) programming community over the last 7 months.
@@ -32,9 +32,9 @@ Perhaps the most notable difference between Hacker News and Reddit is that **it'
 (update: Apparently it _is_ possible to downvote comments, which I never realized. It is [buried in the faq](http://ycombinator.com/newsfaq.html):)
 
 
-<blockquote>**Why don't I see down arrows?**
+> **Why don't I see down arrows?**
 
-There are no down arrows on submissions. They only appear on comments after users reach a certain karma threshold [ed: this is unstated for some bizarre reason, but it is currently 100].</blockquote>
+> There are no down arrows on submissions. They only appear on comments after users reach a certain karma threshold [ed: this is unstated for some bizarre reason, but it is currently 100].
 
 
 (I apologize for my misunderstanding, but there's no visible UI for downvoting, and I can't recall ever seeing a single negative voted comment in all the times I've visited Hacker News! Also, I put these comments in parens to make them extra-LISPy so Paul Graham would see my corrections.)
@@ -54,11 +54,11 @@ If you add back in the negatives, suddenly the range is doubled. An evil or inco
 But getting downvoted isn't anyone's idea of a good time. It's tempting to disallow it entirely, to avoid [this inevitable discussion](http://stackoverflow.uservoice.com/pages/general/suggestions/133310-discourage-downvoting):
 
 
-<blockquote>Please do something else to discourage downvoting. Maybe increase the cost to the downvoter (there's already a "declined" on force user to comment on downvoting).
+> Please do something else to discourage downvoting. Maybe increase the cost to the downvoter (there's already a "declined" on force user to comment on downvoting).
 
-This isn't about points. It's about participation. Downvoting should be reserved for nasty/offensive/stupid/poorly-thought-out/totally-off-base comments. If someone spends the time to make an honest effort to answer a question, but it's not that great an answer, just don't upvote them... Downvoting sends a message, "We disapprove. You spent your valuable time, but we don't care." It makes me think, why should I bother spending the time to write up answers for this forum?
+> This isn't about points. It's about participation. Downvoting should be reserved for nasty/offensive/stupid/poorly-thought-out/totally-off-base comments. If someone spends the time to make an honest effort to answer a question, but it's not that great an answer, just don't upvote them... Downvoting sends a message, "We disapprove. You spent your valuable time, but we don't care." It makes me think, why should I bother spending the time to write up answers for this forum?
 
-I stopped posting on several usenet newsgroups because the major participants were just nasty and sarcastic. Don't let this happen to Stack Overflow.</blockquote>
+> I stopped posting on several usenet newsgroups because the major participants were just nasty and sarcastic. Don't let this happen to Stack Overflow.
 
 
 You could argue that the saner level of discussion on Hacker News is because downvotes are disallowed. I'm not so sure; I think it's more attributable to the fact that Hacker News is relatively young, having launched in February 2007, and the small (but growing) size of the community.

--- a/_posts/2009-03-15-stack-overflow-and-bizspark.markdown
+++ b/_posts/2009-03-15-stack-overflow-and-bizspark.markdown
@@ -117,7 +117,7 @@ If you'd like to get started, [check the BizSpark website](http://www.microsoft.
 
 
 <blockquote>
-Bizspark friends please RT: if you need a invitation code to join Bizspark, just email [BizSpark@microsoft.com](mailto:bizspark@microsoft.com), we will sign you up !
+Bizspark friends please RT: if you need a invitation code to join Bizspark, just email <a href="mailto:bizspark@microsoft.com">BizSpark@microsoft.com</a>, we will sign you up !
 </blockquote>
 
 

--- a/_posts/2009-03-16-it-stack-overflow-update-naming-is-hard.markdown
+++ b/_posts/2009-03-16-it-stack-overflow-update-naming-is-hard.markdown
@@ -62,15 +62,15 @@ I've noted many times that naming is one of the hardest things in programming, a
 
 
 <blockquote>
-The Naming of Cats is a difficult matter,
-It isn't just one of your holiday games
-...
-When you notice a cat in profound meditation,
-The reason, I tell you, is always the same:
-His mind is engaged in a rapt contemplation
-Of the thought, of the thought, of the thought of his name:
-His ineffable effable
-Effanineffable
+The Naming of Cats is a difficult matter,<br/>
+It isn't just one of your holiday games<br/>
+...<br/>
+When you notice a cat in profound meditation,<br/>
+The reason, I tell you, is always the same:<br/>
+His mind is engaged in a rapt contemplation<br/>
+Of the thought, of the thought, of the thought of his name:<br/>
+His ineffable effable<br/>
+Effanineffable<br/>
 Deep and inscrutable singular Name.
 </blockquote>
 

--- a/_posts/2009-04-05-what-stack-overflow-can-teach-you.markdown
+++ b/_posts/2009-04-05-what-stack-overflow-can-teach-you.markdown
@@ -23,7 +23,7 @@ But I do want to share with you one of those emails, the one that made me proude
 
 
 
-<blockquote>
+>
 I'm not sure if you have thought about this side effect or not, but **Stack Overflow has taught me more about writing effectively than any class I've taken, book I've read, or any other experience I have had before**.
 
 > 
@@ -37,7 +37,7 @@ Over the course of the past 5 months all the answers I've been writing have been
 > 
 > 
 I know that you said that writing your Coding Horror blog helped you greatly in [refining your writing over the years](http://www.codinghorror.com/blog/archives/001184.html).  Stack Overflow has been doing the same for me and I just wanted to thank you for the opportunity.  I've decided to setup a coding blog in your footsteps and I just registered a domain today.  Hopefully that will go as well as writing on SO has. There are no tougher critics than fellow programmers who scrutinize every detail, every technical remark and grammar structure looking for mistakes.  If you can effectively write for and be accepted by a group of programmers you can write for anyone.
-</blockquote>
+
 
 
 
@@ -49,13 +49,13 @@ There's nothing I respect more than a great programmer. But if you can manage to
 
 
 
-<blockquote>
+>
 The difference between a tolerable programmer and a great programmer is not how many programming languages they know, and it's not whether they prefer Python or Java. **It's whether they can communicate their ideas.** By persuading other people, they get leverage. By writing clear comments and technical specs, they let other programmers understand their code, which means other programmers can use and work with their code instead of rewriting it. Absent this, their code is worthless. By writing clear technical documentation for end users, they allow people to figure out what their code is supposed to do, which is the only way those users can see the value in their code. There's a lot of wonderful, useful code buried on sourceforge somewhere that nobody uses because it was created by programmers who don't write very well (or don't write at all), and so nobody knows what they've done and their brilliant code languishes.
 
 > 
 > 
 I won't hire a programmer unless they can write, and write well, in English. If you can write, wherever you get hired, you'll soon find that you're getting asked to write the specifications and that means you're already leveraging your influence and getting noticed by management. 
-</blockquote>
+
 
 
 

--- a/_posts/2009-04-08-in-defense-of-editing.markdown
+++ b/_posts/2009-04-08-in-defense-of-editing.markdown
@@ -27,7 +27,7 @@ As it says in [the FAQ](http://stackoverflow.com/faq):
 
 
 
-<blockquote>
+>
 
 > 
 > ## Other people can edit my stuff?!
@@ -37,7 +37,7 @@ As it says in [the FAQ](http://stackoverflow.com/faq):
 > 
 > 
 Like Wikipedia, this site is collaboratively edited. If you are not comfortable with the idea of your questions and answers being edited by other trusted users, this may not be the site for you.
-</blockquote>
+
 
 
 

--- a/_posts/2009-04-13-stack-overflow-voting-pattern-analysis.markdown
+++ b/_posts/2009-04-13-stack-overflow-voting-pattern-analysis.markdown
@@ -22,13 +22,13 @@ The reputation scores follow the expected power law distribution. No surprise th
 
 
 
-<blockquote>
+>
 This graph was based on a snapshot of the user reputations one day last week. The largest group, 15,219 users, had reputation less than 100. There were 2,494 users with reputation between 100 and 200, etc. The number of users in a 100-point reputation range generally decreases as the reputation score increases. The majority of users have reputation less than 100, and yet the top percentile have reputations over 4,800 and the highest reputation was 38,700. This sort of extreme disparity suggests a power law distribution.
 
 > 
 > 
 The test for whether the reputation scores follow a power law is to plot the logarithms of the number of people with each score and look for a straight line. And after an initial steep drop off, **the logs of the counts do fall roughly on a straight line**.
-</blockquote>
+
 
 
 
@@ -42,7 +42,7 @@ John's summary:
 
 
 
-<blockquote>
+>
 
 > 
 > 
@@ -61,7 +61,7 @@ I think this last fact speaks well of the users on the site. The people who rece
 > 
 > 
 **You could view reputation as a measure of how invested someone is in the site, not just a measure of their perceived competence.**
-</blockquote>
+
 
 
 

--- a/_posts/2009-04-22-how-many-questions-are-closed-or-deleted.markdown
+++ b/_posts/2009-04-22-how-many-questions-are-closed-or-deleted.markdown
@@ -20,13 +20,13 @@ Based on the discussion about [The Stack Overflow Question Lifecycle](http://blo
 
 
 
-<blockquote>
+>
 [Programming Related](http://blog.stackoverflow.com/2008/10/a-question-about-questions/) Queston -> Answers!
 
 > 
 > 
 [Non-Programming Related](http://blog.stackoverflow.com/2008/10/a-question-about-questions/) Question -> Closed -> Deleted (eventually, depending)
-</blockquote>
+
 
 
 

--- a/_posts/2009-04-30-server-fault-private-beta-begins.markdown
+++ b/_posts/2009-04-30-server-fault-private-beta-begins.markdown
@@ -21,7 +21,7 @@ We're launching the Server Fault private beta tonight. What is Server Fault?
 
 
 
-<blockquote>
+>
 **Server Fault is for system administrators and IT professionals, people who manage or maintain computers in a professional capacity**. If you are in charge of ...
 
 > 
@@ -37,7 +37,7 @@ We're launching the Server Fault private beta tonight. What is Server Fault?
 >   * many desktop PCs (other than your own)
 
 ... then you're in the right place to ask your question! Well, as long as the question is about your servers, your networks, or your desktops, anyway.
-</blockquote>
+
 
 
 

--- a/_posts/2009-05-07-interesting-and-ignored-tags-now-support-wildcards.markdown
+++ b/_posts/2009-05-07-interesting-and-ignored-tags-now-support-wildcards.markdown
@@ -54,7 +54,7 @@ Unfortunately, the solution proposed there, [JQuery filters](http://docs.jquery.
 
 
 <blockquote>
-A recent question on Stack Overflow posed a common question concerning DOM insertion and specifically the dire performance of IE6 when using innerHTML to parse a large amount of HTML markup. [Head over there](http://stackoverflow.com/questions/788614/ways-to-increase-performance-when-set-big-value-to-innerhtml) to read the question for yourself. I thought it worth sharing my solution;
+A recent question on Stack Overflow posed a common question concerning DOM insertion and specifically the dire performance of IE6 when using innerHTML to parse a large amount of HTML markup. <a href="http://stackoverflow.com/questions/788614/ways-to-increase-performance-when-set-big-value-to-innerhtml">Head over there</a> to read the question for yourself. I thought it worth sharing my solution;
 </blockquote>
 
 

--- a/_posts/2009-05-12-stack-overflow-developer-days-conference.markdown
+++ b/_posts/2009-05-12-stack-overflow-developer-days-conference.markdown
@@ -19,7 +19,7 @@ Joel mentioned this in passing on one of the podcasts, but I didn't want to stea
 
 
 
-<blockquote>
+>
 We decided to launch a series of Stack Overflow events: the first gathering of the tribe of great developers making Stack Overflow so successful that [over 90% of questions get answered](http://blog.stackoverflow.com/2009/05/joel-talks-about-stack-overflow-at-google/).
 
 > 
@@ -62,7 +62,7 @@ For smart programmers who are interested in learning about something a little bi
 > 
 > 
 The conference is for programmers. The conversation is going to be hard core. Speakers are going to be writing code.
-</blockquote>
+
 
 
 

--- a/_posts/2009-05-15-nowearn-valuable-flair.markdown
+++ b/_posts/2009-05-15-nowearn-valuable-flair.markdown
@@ -20,7 +20,7 @@ You know what you need? Besides a haircut, I mean? [More flair](http://www.imsdb
 
 
 
-<blockquote>
+>
 
 > 
 > 
@@ -75,7 +75,7 @@ terrific smile.
 **People can get a cheeseburger anywhere, ok? They come to Chotchkie's 
 for the atmosphere and the attitude. That's what the flair's about. 
 It's about fun.
-</blockquote>
+
 
 
 

--- a/_posts/2009-05-17-server-fault-public-beta-nears.markdown
+++ b/_posts/2009-05-17-server-fault-public-beta-nears.markdown
@@ -30,7 +30,7 @@ But we can do better. I am making some tentative efforts to reach out to the sys
 
 
 <blockquote>
-Richard and Greg talk to Jeff Atwood of Stack Overflow fame about being a developer who also maintains infrastructure. Jeff also talks about his new site, [Server Fault](http://serverfault.com), which is a Question and Answer site for the IT Professional. Great discussions about adventures in RAID controllers and NIC drivers and how FireBug can diagnose your network problems.
+Richard and Greg talk to Jeff Atwood of Stack Overflow fame about being a developer who also maintains infrastructure. Jeff also talks about his new site, <a href="http://serverfault.com">Server Fault</a>, which is a Question and Answer site for the IT Professional. Great discussions about adventures in RAID controllers and NIC drivers and how FireBug can diagnose your network problems.
 </blockquote>
 
 

--- a/_posts/2009-05-20-linking-duplicate-questions.markdown
+++ b/_posts/2009-05-20-linking-duplicate-questions.markdown
@@ -58,7 +58,7 @@ Remember, in some cases we may want [duplicate questions](http://blog.stackoverf
 
 
 <blockquote>
-There’s often benefit to having multiple subtle variants of a question around, as people **tend to ask and search using completely different words**, and the better our coverage, the better odds our fellow programmers can find the answer they’re looking for. 
+There’s often benefit to having multiple subtle variants of a question around, as people <strong>tend to ask and search using completely different words</strong>, and the better our coverage, the better odds our fellow programmers can find the answer they’re looking for.
 </blockquote>
 
 

--- a/_posts/2009-05-27-server-fault-public-beta-launches.markdown
+++ b/_posts/2009-05-27-server-fault-public-beta-launches.markdown
@@ -17,13 +17,13 @@ tags:
 
 
 
-<blockquote>
+>
 Q: How do geeks know it's a holiday?
 
 > 
 > 
 A: Because the Google logo changed.
-</blockquote>
+
 
 
 

--- a/_posts/2009-06-26-enthusiast-and-fanatic-badges.markdown
+++ b/_posts/2009-06-26-enthusiast-and-fanatic-badges.markdown
@@ -29,7 +29,7 @@ They also have a clever crap-selling website that we've referred to more than on
 
 
 <blockquote>
-**Enthusiast** -- visited the site each day for 30 days.
+<strong>Enthusiast</strong> -- visited the site each day for 30 days.
 </blockquote>
 
 

--- a/_posts/2009-07-10-this-just-in-stack-overflow-defeats-google.markdown
+++ b/_posts/2009-07-10-this-just-in-stack-overflow-defeats-google.markdown
@@ -19,7 +19,7 @@ We knew in our hearts this day would come: _Stack Overflow has defeated Google!_
 
 
 
-<blockquote>
+>
 On July 2, from 6:45 AM PDT until 12:35 PM PDT, Google App Engine (App Engine) experienced an outage that ranged from partial to complete.
 
 > 
@@ -33,7 +33,6 @@ The GFS failure was abrupt for reasons described below, and as a consequence the
 > 
 > 
 The root cause of the outage was a bug in the GFS Master server caused by another client in the datacenter sending it an improperly formed filehandle which had not been safely sanitized on the server side, and **thus caused a stack overflow on the Master when processed.** 
-</blockquote>
 
 
 

--- a/_posts/2009-07-13-reversal-and-pundit-badges.markdown
+++ b/_posts/2009-07-13-reversal-and-pundit-badges.markdown
@@ -20,7 +20,6 @@ Two new badges today:
 
 
 
-<blockquote>
 
 > 
 > ## [Reversal](http://stackoverflow.com/badges/95/reversal)
@@ -30,7 +29,6 @@ Two new badges today:
 > 
 > 
 Provided an answer upvoted 20 or more times to a question that was downvoted 5 or more times. (gold)
-</blockquote>
 
 
 
@@ -41,7 +39,6 @@ Provided an answer upvoted 20 or more times to a question that was downvoted 5 o
 
 
 
-<blockquote>
 
 > 
 > ## [Pundit](http://stackoverflow.com/badges/94/pundit)
@@ -51,7 +48,6 @@ Provided an answer upvoted 20 or more times to a question that was downvoted 5 o
 > 
 > 
 Left 10 comments with a score of 10 or more. (silver)
-</blockquote>
 
 
 

--- a/_posts/2009-07-14-migrate-questions-between-websites.markdown
+++ b/_posts/2009-07-14-migrate-questions-between-websites.markdown
@@ -22,13 +22,13 @@ First, I've got a little joke for you, [courtesy of Kip and TheTxi](http://meta.
 
 
 
-<blockquote>
+>
 A doctor, a lawyer, and a rabbi log into Stack Overflow.
 
 > 
 > 
 The bartender looks at them and says "sorry, you guys are not programming related."
-</blockquote>
+
 
 
 

--- a/_posts/2009-07-15-super-user-semi-private-beta-begins.markdown
+++ b/_posts/2009-07-15-super-user-semi-private-beta-begins.markdown
@@ -29,7 +29,7 @@ That's right, it is officially [Ewok Time](http://blog.stackoverflow.com/2009/05
 
 
 
-<blockquote>
+>
 At any rate, **if you wanted a community where (almost) anything goes, you're about to get exactly what you asked for in the form of [superuser.com](http://superuser.com)**. If your question has to do with _computers_, it will be allowed there.
 > 
 > 
@@ -45,7 +45,7 @@ At any rate, **if you wanted a community where (almost) anything goes, you're ab
 But then again, _so are Ewoks_. Be careful what you ask for, I guess.
 > 
 > 
-</blockquote>
+
 
 
 

--- a/_posts/2009-07-22-stack-overflow-flash-mobs.markdown
+++ b/_posts/2009-07-22-stack-overflow-flash-mobs.markdown
@@ -24,7 +24,7 @@ The premise of the BOF session is intriguing; it's not at all what I expected:
 
 
 
-<blockquote>
+>
 In concert with users online across the country, this session will lead **a flashmob to populate Stack Overflow with [R language content](http://stackoverflow.com/questions/tagged/r)**.
 
 > 
@@ -42,7 +42,7 @@ In the first hour, participants will pair up to claim a question, formulate it o
 > 
 > 
 While Stackoverflow currently lacks content for the R language, we believe this effort will provide the spark to attract more R users, and emerge as a valuable resource to the growing R community.
-</blockquote>
+
 
 
 

--- a/_posts/2009-07-26-why-cant-you-have-just-one-site.markdown
+++ b/_posts/2009-07-26-why-cant-you-have-just-one-site.markdown
@@ -124,7 +124,7 @@ Do you think anyone sets up camp outside the League of Justice with a bullhorn, 
 
 
 <blockquote>
-It's too confusing to keep track of all you super heroes! Which one has which power, and should be used to fight which enemy? Which one is the right one to help us out in an hour of need? **Why can't there just be one giant superhero, SuperBatGreenMartianFlashHawkManWoman??**
+It's too confusing to keep track of all you super heroes! Which one has which power, and should be used to fight which enemy? Which one is the right one to help us out in an hour of need? <strong>Why can't there just be one giant superhero, SuperBatGreenMartianFlashHawkManWoman??</strong>
 </blockquote>
 
 

--- a/_posts/2009-07-31-happy-sysadmin-appreciation-day.markdown
+++ b/_posts/2009-07-31-happy-sysadmin-appreciation-day.markdown
@@ -26,7 +26,7 @@ There's a rather nice definition of the term **sysadmin** on the page, so if you
 
 
 
-<blockquote>
+>
  A **sysadmin** unpacked the server for this website from its box, installed an operating system, patched it for security, made sure the power and air conditioning was working in the server room, monitored it for stability, set up the software, and kept backups in case anything went wrong. All to serve this webpage.
 
 > 
@@ -52,7 +52,7 @@ A **sysadmin** is a professional, who plans, worries, hacks, fixes, pushes, advo
 > 
 > 
 So if you can read this, thank your **sysadmin** -- and know he or she is only one of dozens or possibly hundreds whose work brings you the email from your aunt on the West Coast, the instant message from your son at college, the free phone call from the friend in Australia, and this webpage.
-</blockquote>
+
 
 
 

--- a/_posts/2009-08-01-one-year-of-stack-overflow.markdown
+++ b/_posts/2009-08-01-one-year-of-stack-overflow.markdown
@@ -63,13 +63,13 @@ If this thing we've been doing for the past year has been a success, I can't tak
 
 
 
-<blockquote>
+>
 This is the scary part, the great leap of faith that Stack Overflow is predicated on: **trusting your fellow programmers**. The programmers who choose to participate in Stack Overflow are the “secret sauce” that makes it work. You are the reason I continue to believe in developer community as the greatest source of learning and growth. You are the reason I continue to get so many positive emails and testimonials about Stack Overflow. I can’t take credit for that. But you can.
 
 > 
 > 
 I learned the collective power of my fellow programmers long ago writing on Coding Horror. The community is far, far smarter than I will ever be. All I can ask — all any of us can ask — is to help each other along the path.
-</blockquote>
+
 
 
 

--- a/_posts/2009-08-09-a-few-speed-improvements.markdown
+++ b/_posts/2009-08-09-a-few-speed-improvements.markdown
@@ -43,7 +43,7 @@ One of the [last remaining YSlow / Page Speed recommendations](http://meta.stack
 
 
 
-<blockquote>
+>
 When the browser makes a request for a static image and sends cookies together with the request, the server doesn't have any use for those cookies. So they only create network traffic for no good reason. You should make sure static components are requested with cookie-free requests. Create a subdomain and host all your static components there.
 
 > 

--- a/_posts/2009-08-12-stack-overflow-and-doctype.markdown
+++ b/_posts/2009-08-12-stack-overflow-and-doctype.markdown
@@ -39,13 +39,13 @@ Well, I'm pleased to announce we have recruited another superhero into our leagu
 
 
 
-<blockquote>
+>
 Doctype is a free question and answer site for web designers. You can get fast solutions to your CSS, HTML, web design and email design problems.
 
 > 
 > 
 For each question, **Doctype can generate screenshots of your design on any browser or email client**. This makes it much easier for other people to see the problem and help you fix it.
-</blockquote>
+
 
 
 

--- a/_posts/2009-09-09-how-to-get-stack-overflow-stickers.markdown
+++ b/_posts/2009-09-09-how-to-get-stack-overflow-stickers.markdown
@@ -39,9 +39,9 @@ Simply **mail a Self-Addressed Stamped Envelope** to:
 
 
 <blockquote>
-Stack Overflow Stickers
-Stack Exchange, Inc
-110 William St, 28th Floor
+Stack Overflow Stickers<br/>
+Stack Exchange, Inc<br/>
+110 William St, 28th Floor<br/>
 New York, NY 10038
 </blockquote>
 

--- a/_posts/2009-10-07-introducing-stack-overflow-careers.markdown
+++ b/_posts/2009-10-07-introducing-stack-overflow-careers.markdown
@@ -22,7 +22,7 @@ When we integrated [jobs.stackoverflow.com](http://jobs.stackoverflow.com/), I d
 
 
 <blockquote>
-That said, this is just a start on the careers front. We have some more innovative things we are working on in this area that we hope to roll out in the next 6 to 8 weeks. Like, say, wouldn’t it be cool if your CV listed the stuff programmers really care about, such as [your first computer](http://stackoverflow.com/questions/102714/what-was-your-first-home-computer) …
+That said, this is just a start on the careers front. We have some more innovative things we are working on in this area that we hope to roll out in the next 6 to 8 weeks. Like, say, wouldn’t it be cool if your CV listed the stuff programmers really care about, such as <a href="http://stackoverflow.com/questions/102714/what-was-your-first-home-computer">your first computer</a> …
 </blockquote>
 
 
@@ -47,7 +47,7 @@ Sam Saffron correctly identified our key goals in a [speculative meta post](http
 
 
 
-<blockquote>
+>
 I know what you're thinking, there is already the woeful non-international, poorly targeted, tiny note on every page and a check box on your profile that does nothing.
 
 > 
@@ -65,7 +65,7 @@ Nonetheless, employers are willing to pay lots of money to find good people, and
 >   * Create a new entity that does jobs better, partner with local job agencies.
 
 >   * Collect more information from the end users. Eg. Would you be willing to move? Would you be willing to work from home? Looking for contract or full time? Etc …
-</blockquote>
+
 
 
 

--- a/_posts/2009-10-23-alternate-sorting-orders.markdown
+++ b/_posts/2009-10-23-alternate-sorting-orders.markdown
@@ -72,7 +72,7 @@ He also provided some sample Ruby code that implements the above formula:
 
 
 <blockquote>
-**pos** is the number of positive rating, **n** is the total number of ratings, and power refers to the statistical power: pick 0.10 to have a 95% chance that your lower bound is correct, 0.05 to have a 97.5% chance, etc.
+<strong>pos</strong> is the number of positive rating, <strong>n</strong> is the total number of ratings, and power refers to the statistical power: pick 0.10 to have a 95% chance that your lower bound is correct, 0.05 to have a 97.5% chance, etc.
 </blockquote>
 
 

--- a/_posts/2009-11-05-our-amazon-advertising-experiment.markdown
+++ b/_posts/2009-11-05-our-amazon-advertising-experiment.markdown
@@ -40,7 +40,7 @@ Thus, Portman generously offered to build a custom ad-serving site for us, which
 
 
 
-<blockquote>
+>
 Rads has three main components:
 
 > 
@@ -59,7 +59,7 @@ Rads has three main components:
 > 
 > 
 The spider was fed the top 5000 tags on Stack Overflow. For each tag, it preformed a keyword search on the “Computers & Internet” node, returning the top 10 books with five-star reviews, sorted by number of reviews.
-</blockquote>
+
 
 
 

--- a/_posts/2009-12-28-introducing-markdownsharp.markdown
+++ b/_posts/2009-12-28-introducing-markdownsharp.markdown
@@ -28,7 +28,7 @@ Since [the original C# library we used for Markdown](http://aspnetresources.com/
 
 
 
-<blockquote>
+>
 Hi there, guys!
 
 > 
@@ -40,7 +40,7 @@ Sure, I don’t mind at all. I’ve always wanted the community to improve and c
 Cheers!  
 
 Milan
-</blockquote>
+
 
 
 

--- a/_posts/2010-01-03-new-lower-careers-pricing.markdown
+++ b/_posts/2010-01-03-new-lower-careers-pricing.markdown
@@ -40,13 +40,13 @@ The CV filing fee is not there to make us obscene profits (as _if_), but to ensu
 
 
 
-<blockquote>
+>
 When hiring managers search through CVs, they want to know that they're looking at active, serious job applicants. If it were free to file a CV, a lot of applicants that weren't looking for jobs, or who knew that they had no reasonable chance of getting a job, would post them, making it harder for the employers to find serious applicants.
 
 > 
 > 
-That's why we charge a nominal amount to file a CV. It is, however, absolutely guaranteed, and if you're unhappy or don’t get the result you want, just let us know, and you'll get your money back on the spot. 
-</blockquote>
+That's why we charge a nominal amount to file a CV. It is, however, absolutely guaranteed, and if you're unhappy or don’t get the result you want, just let us know, and you'll get your money back on the spot.
+
 
 
 

--- a/_posts/2010-01-04-stack-overflow-where-we-hate-fun.markdown
+++ b/_posts/2010-01-04-stack-overflow-where-we-hate-fun.markdown
@@ -37,7 +37,7 @@ I agree this is not exactly an ideal question for Stack Overflow, [per the FAQ](
 
 
 <blockquote>
-**Avoid asking questions that are subjective, argumentative, or require extended discussion**. This is not a discussion board, this is a place for questions that can be answered! 
+<strong>Avoid asking questions that are subjective, argumentative, or require extended discussion</strong>. This is not a discussion board, this is a place for questions that can be answered!
 </blockquote>
 
 

--- a/_posts/2010-01-22-careers-success-stories.markdown
+++ b/_posts/2010-01-22-careers-success-stories.markdown
@@ -24,7 +24,7 @@ Here are a few recent success stories people have shared with us:
 
 
 
-<blockquote>
+>
 I was part of a mass layoff around Thanksgiving. That means another job search. So, I published my CV on SO Careers.
 
 > 
@@ -42,7 +42,7 @@ This same employer made me an offer 30 minutes after I left the interview. I am 
 > 
 > 
 --  Sean Massa
-</blockquote>
+
 
 
 
@@ -54,8 +54,8 @@ And another:
 
 
 
-<blockquote>
 I wanted to take a couple minutes to thank you all for your work on Stackoverflow careers.  I filed my CV last year and got my first hit last week.  The employer called me and brought me in for an interview.  Now I'm facing a job offer providing a 30% raise ... what sucks is I like my current job! 
+>
 
 > 
 > 
@@ -64,7 +64,7 @@ I just wanted you all to know your hard work and innovative ideas have impacted 
 > 
 > 
 --  a programmer in Georgia
-</blockquote>
+
 
 
 
@@ -76,7 +76,7 @@ And another:
 
 
 
-<blockquote>
+>
 I was currently employed but was in that 25% at DevDays that "hated their job and couldn’t wait to find something better." It wasn't the people I worked with or the work that I did necessarily; it was the culture and the nature of being in a "corporate" job; it was so political and difficult to get the tools I needed to do my job in the best way that I could (I ended up buying my own tools such as R# and even my own keyboard and mouse).
 
 > 
@@ -94,7 +94,7 @@ Thanks to all of you for building this community that has provided me and other 
 > 
 > 
 -- Jon Erickson
-</blockquote>
+
 
 
 
@@ -103,7 +103,7 @@ Thanks to all of you for building this community that has provided me and other 
 And another:
 
 
-<blockquote>
+>
 Stack Overflow Careers was directly responsible for me landing the perfect job at a local company here in Washington, DC. I am finally escaping the pain and suffering of being a government programmer.
 
 > 
@@ -121,7 +121,7 @@ I will absolutely recommend your product to all of my co-workers at my old offic
 > 
 > 
 -- Ryan Michela
-</blockquote>
+
 
 
 

--- a/_posts/2010-01-25-six-whys-or-never-trust-your-network-switch.markdown
+++ b/_posts/2010-01-25-six-whys-or-never-trust-your-network-switch.markdown
@@ -22,7 +22,7 @@ Remember [Joel Spolsky's fine article "Five Whys"?](http://www.joelonsoftware.co
 
 
 <blockquote>
-Michael spent some time doing a post-mortem, and discovered that the problem was a simple configuration problem on the switch. **There are several possible speeds that a switch can use to communicate (10, 100, or 1000 megabits/second). You can either set the speed manually, or you can let the switch automatically negotiate the highest speed that both sides can work with.** The switch that failed had been set to autonegotiate. This usually works, but not always, and on the morning of January 10th, it didn't.
+Michael spent some time doing a post-mortem, and discovered that the problem was a simple configuration problem on the switch. <strong>There are several possible speeds that a switch can use to communicate (10, 100, or 1000 megabits/second). You can either set the speed manually, or you can let the switch automatically negotiate the highest speed that both sides can work with.</strong> The switch that failed had been set to autonegotiate. This usually works, but not always, and on the morning of January 10th, it didn't.
 </blockquote>
 
 

--- a/_posts/2010-01-29-open-source-ad-stats.markdown
+++ b/_posts/2010-01-29-open-source-ad-stats.markdown
@@ -49,7 +49,7 @@ Remember, all it takes is a valid ad image and link posted to [current meta ads 
 
 
 <blockquote>
-It must be an advertisement **soliciting the participation and contribution of programmers writing actual source code.** This is not intended as a general purpose ad for consumer products which just happen to be open source. It's for finding programmers who will help contribute code or other programmery things (documentation, code review, bugfixes, etc).
+It must be an advertisement <strong>soliciting the participation and contribution of programmers writing actual source code.</strong> This is not intended as a general purpose ad for consumer products which just happen to be open source. It's for finding programmers who will help contribute code or other programmery things (documentation, code review, bugfixes, etc).
 </blockquote>
 
 

--- a/_posts/2010-02-07-thermal-event-at-datacenter.markdown
+++ b/_posts/2010-02-07-thermal-event-at-datacenter.markdown
@@ -69,7 +69,7 @@ Update: PEAK official statement
 
 
 
-<blockquote>
+>
 The PEAK HVAC system consist of two cooling systems which both operate to provide cooling to the pressurized floor of data center. One system is a 5-ton and the second is a 10-ton unit.
 
 > 
@@ -87,7 +87,7 @@ Our HVAC vendor was dispatched and arrived on-site by 4:00am.  The vendor locate
 > 
 > 
 PEAK Engineers are looking into why this failure caused a significant rise in the Data Center temperature.  Based on our findings, PEAK will take the necessary actions to ensure a failure of  one systems does not cause a significant change in the Data Center temperature.  We will provide this information once it becomes available.
-</blockquote>
+
 
 
 

--- a/_posts/2010-02-09-stack-overflow-2010-moderator-election-results.markdown
+++ b/_posts/2010-02-09-stack-overflow-2010-moderator-election-results.markdown
@@ -53,13 +53,13 @@ Per the [OpenSTV FAQ](http://www.openstv.org/faq), we used the most accurate for
 
 
 
-<blockquote>
+>
 If you are electing one person and simplicity is not important, then we recommend Condorcet voting. Most people agree that Condorcet is the best method for electing one person, but it is more difficult to explain.
 
 > 
 > 
 If you are electing multiple people and simplicity is not important, then we recommend Meek STV. **Most people agree that Meek STV is the best variant of STV, but it can only be implemented with a computer program.**
-</blockquote>
+
 
 
 

--- a/_posts/2010-02-10-whatever-were-doing-together-apparently-its-working.markdown
+++ b/_posts/2010-02-10-whatever-were-doing-together-apparently-its-working.markdown
@@ -19,13 +19,13 @@ We are in the enviable position of getting some very nice emails, as [I might ha
 
 
 
-<blockquote>
+>
 Just wanted to commend you on the fantastic site. I have heard a little of the behind-the-scenes so I know a lot of thought has gone into it, and I really like the result-- the community feels both professional and neighborly, with folks just helping out folks. And the really nice bit is that it's a one-stop-shop for many platforms/environments, completely obsoleting my need to be on random closed mailing lists and plunge through badly threaded forum archive viewers for the stuff I care about.
 
 > 
 > 
 You've really moved the vanguard forward for tech resources. Keep up the great work.
-</blockquote>
+
 
 
 
@@ -37,7 +37,7 @@ And also:
 
 
 
-<blockquote>
+>
 Just wanted to drop a note to the team and say thanks for building this site! It's very nearly free from a lot of things that forum/community solutions are plagued with, namely:
 
 > 
@@ -62,7 +62,7 @@ I've only been using it for a few weeks, but it feels like pure, unfiltered codi
 > 
 > 
 It's a breath of fresh air that encourages this really positive feeling in me - which makes me stop and take the time to answer others' questions, just because I find the site so damn helpful.
-</blockquote>
+
 
 
 

--- a/_posts/2010-03-16-more-trilogy-sites.markdown
+++ b/_posts/2010-03-16-more-trilogy-sites.markdown
@@ -29,7 +29,7 @@ I was amused to discover [this hilarious Onion article](http://www.theonion.com/
 
 
 
-<blockquote>
+>
 "I don't know how I wound up at that point, but thank God I escaped when I did," Gibson, 41, said Friday. "There I was, a grown man, planning a trip to the Mustard Museum in Wisconsin, when suddenly I heard a voice deep within me say, 'This is not what you want your life to be about.'"
 
 > 
@@ -43,7 +43,7 @@ I was amused to discover [this hilarious Onion article](http://www.theonion.com/
 > 
 > 
 Gibson's descent into the depths of mustard obsession started innocently enough, when he got involved in an Internet exchange about the best kind of mustard to use on a grilled bratwurst. When someone posted a link encouraging him to "click on this if you really want to spice things up," he took the stranger's advice and suddenly found himself on MustardMonster.com, a discussion group devoted to the cultivation, preparation, and enjoyment of the table-side condiment.
-</blockquote>
+
 
 
 

--- a/_posts/2010-04-13-openid-one-year-later.markdown
+++ b/_posts/2010-04-13-openid-one-year-later.markdown
@@ -50,7 +50,7 @@ First, to understand our position on OpenID, please read [Does The World Really 
 
 
 <blockquote>
-I realize that OpenID is far from an ideal solution. But **right now, the one-login-per-website problem is so bad that I am willing to accept these tradeoffs for a partial worse is better solution**. There's absolutely no way I'd put my banking credentials behind an OpenID. But there are also dozens of sites that I don't need anything remotely approaching banking-grade security for, and I use these sites far more often than my bank. The collective pain of remembering all these logins -- and the way my email inbox becomes a de-facto collecting point and security gateway for all of them -- is substantial.
+I realize that OpenID is far from an ideal solution. But <strong>right now, the one-login-per-website problem is so bad that I am willing to accept these tradeoffs for a partial worse is better solution</strong>. There's absolutely no way I'd put my banking credentials behind an OpenID. But there are also dozens of sites that I don't need anything remotely approaching banking-grade security for, and I use these sites far more often than my bank. The collective pain of remembering all these logins -- and the way my email inbox becomes a de-facto collecting point and security gateway for all of them -- is substantial.
 </blockquote>
 
 

--- a/_posts/2010-04-29-do-trilogy-sites-need-a-third-place.markdown
+++ b/_posts/2010-04-29-do-trilogy-sites-need-a-third-place.markdown
@@ -61,7 +61,7 @@ After discussing this with quite a few folks, I am wondering if we might need _a
 
 
 <blockquote>
-The third place is a term used in the concept of community building to refer to social surroundings separate from the two usual social environments of **home** and the **workplace**. In his influential book The Great Good Place, Ray Oldenburg argues that third places are important for civil society, democracy, civic engagement, and establishing feelings of a sense of place.
+The third place is a term used in the concept of community building to refer to social surroundings separate from the two usual social environments of <strong>home</strong> and the <strong>workplace</strong>. In his influential book The Great Good Place, Ray Oldenburg argues that third places are important for civil society, democracy, civic engagement, and establishing feelings of a sense of place.
 </blockquote>
 
 

--- a/_posts/2010-06-07-new-protected-question-status.markdown
+++ b/_posts/2010-06-07-new-protected-question-status.markdown
@@ -26,7 +26,7 @@ Protected questions are indicated in the standard question footer like so:
 
 
 
-<blockquote>
+>
 
 > 
 > ## protected by {moderator name} 3 days ago
@@ -37,7 +37,7 @@ Protected questions are indicated in the standard question footer like so:
 > This question is protected to prevent "thanks", "me too!", and spam posts from new users. To answer it, you must have more than 10 reputation.
 > 
 > 
-</blockquote>
+
 
 
 

--- a/_posts/2010-06-08-guidelines-for-use-of-our-logo-and-name.markdown
+++ b/_posts/2010-06-08-guidelines-for-use-of-our-logo-and-name.markdown
@@ -22,11 +22,7 @@ Since the Stack Exchange API went into [public beta](http://blog.stackoverflow.c
 
 
 <blockquote>
-
-> 
-> ## How can I use the Stack Overflow | Server Fault | Super User name and logo in my application?
-> 
-> 
+  <h2>How can I use the Stack Overflow | Server Fault | Super User name and logo in my application?</h2>
 </blockquote>
 
 
@@ -73,7 +69,7 @@ We tried our best to avoid [legalese](http://en.wikipedia.org/wiki/Legal_writing
 
 
 <blockquote>
-Legalese is an English term first used in 1914 for legal writing that is designed to be difficult for laymen to read and understand, the implication being that this abstruseness is deliberate for excluding the legally untrained and to justify high fees. Legalese, as a term, has been adopted in other languages. Legalese is characterized by long sentences, many modifying clauses, complex vocabulary, high abstraction, and insensitivity to the layman's need to understand the document's gist. Legalese arises most commonly in legal drafting, yet appears in both types of legal analysis. Today, the [Plain Language Movement](http://en.wikipedia.org/wiki/Plain_Language_Movement) in legal writing is progressing and experts are busy trying to demystify legalese.
+Legalese is an English term first used in 1914 for legal writing that is designed to be difficult for laymen to read and understand, the implication being that this abstruseness is deliberate for excluding the legally untrained and to justify high fees. Legalese, as a term, has been adopted in other languages. Legalese is characterized by long sentences, many modifying clauses, complex vocabulary, high abstraction, and insensitivity to the layman's need to understand the document's gist. Legalese arises most commonly in legal drafting, yet appears in both types of legal analysis. Today, the <a href="http://en.wikipedia.org/wiki/Plain_Language_Movement">Plain Language Movement</a> in legal writing is progressing and experts are busy trying to demystify legalese.
 </blockquote>
 
 

--- a/_posts/2010-06-10-improved-question-merging.markdown
+++ b/_posts/2010-06-10-improved-question-merging.markdown
@@ -77,7 +77,7 @@ The source merge question isn't deleted, yet; once its answers have been merged 
 
 
 
-<blockquote>
+>
 
 > 
 > ## merged by Jeff Atwood ♦ 8 secs ago
@@ -88,7 +88,7 @@ The source merge question isn't deleted, yet; once its answers have been merged 
 > this question was merged with [Regular expression to find URLs not inside a hyperlink](http://stackoverflow.com/questions/1315653/regular-expression-to-find-urls-not-inside-a-hyperlink) because it is an exact duplicate of that question.
 > 
 > 
-</blockquote>
+
 
 
 

--- a/_posts/2010-06-23-workin-on-ur-problemz.markdown
+++ b/_posts/2010-06-23-workin-on-ur-problemz.markdown
@@ -48,13 +48,12 @@ But nothing is impossible for our talented community of users -- they totally na
 
 
 
-<blockquote>
+>
 Zoe, a domestic shorthair cat, touches the mouse of a computer during a media preview for The Cat Fanciers’ Association’s championship in New York October 10, 2007.
 
 > 
 > 
 ![](/images/wordpress/cat-zoe.jpg)
-</blockquote>
 
 
 

--- a/_posts/2010-07-07-area-51-first-public-beta.markdown
+++ b/_posts/2010-07-07-area-51-first-public-beta.markdown
@@ -25,13 +25,13 @@ Q&A site for experts and advanced users of web applications.Web Apps was one of 
 We've already received coverage on LifeHacker -- [Web Apps is a Q&A Forum for Web Application Enthusiasts](http://lifehacker.com/5580421/web-apps-is-a-qa-forum-for-web-application-enthusiasts). I don't think I can sum up our enthusiasm any better than they did:
 
 
-<blockquote>"Web Apps runs on the same engine and is developed by the same folks who  unleashed the incredible Stack Overflow on the world, and if Web Apps is  as helpful for advanced web users as Stack Overflow is for programmers,  it's definitely a site worth bookmarking."
+>"Web Apps runs on the same engine and is developed by the same folks who  unleashed the incredible Stack Overflow on the world, and if Web Apps is  as helpful for advanced web users as Stack Overflow is for programmers,  it's definitely a site worth bookmarking."
 
 > 
 > _Lifehacker, July, 2010_
 > 
 > 
-</blockquote>
+
 
 
 Come check it out while low user numbers are still available!

--- a/_posts/2010-10-07-membership-has-its-privileges.markdown
+++ b/_posts/2010-10-07-membership-has-its-privileges.markdown
@@ -20,13 +20,12 @@ Our very own Benjamin Dumke opened [a meta topic about a year ago](http://meta.s
 
 
 
-<blockquote>
-Right now, crossing one of the magical rep borders happens more or less unnoticed. People just gain the particular powers. Now, of course they have eagerly been awaiting this moment, and want to start using their new powers instantly.
+> Right now, crossing one of the magical rep borders happens more or less unnoticed. People just gain the particular powers. Now, of course they have eagerly been awaiting this moment, and want to start using their new powers instantly.
 
-However, this leads to people -- usually with good intentions -- doing stuff that is actually discouraged ...
+> However, this leads to people -- usually with good intentions -- doing stuff that is actually discouraged ...
 
-I propose a pop-up saying something like **"You have earned the power to retag questions. Please read our retagging guidelines [link] for a short introduction"**.
-</blockquote>
+> I propose a pop-up saying something like **"You have earned the power to retag questions. Please read our retagging guidelines [link] for a short introduction"**.
+
 
 
 

--- a/_posts/2010-12-23-no-artificial-intelligence-in-area-51.markdown
+++ b/_posts/2010-12-23-no-artificial-intelligence-in-area-51.markdown
@@ -32,9 +32,9 @@ I can understand the curiosity. As a computer enthusiast, I am somewhat intrigue
 AI's problems began almost immediately when users started [asking the first questions](http://blog.stackoverflow.com/2010/07/area-51-asking-the-first-questions/):
 
 
-<blockquote>It has long been established that no question is too entry-level nor too basic. Everyone is welcome. But, in these earliest days, we are DESIGNING a site for experts. To attract experts, you need a site where people are asking very interesting and challenging questions, not the basic questions found on every other Q&A site. Remember, the pro sites WILL attract the enthusiasts, but not the other way around!
+>It has long been established that no question is too entry-level nor too basic. Everyone is welcome. But, in these earliest days, we are DESIGNING a site for experts. To attract experts, you need a site where people are asking very interesting and challenging questions, not the basic questions found on every other Q&A site. Remember, the pro sites WILL attract the enthusiasts, but not the other way around!
 
-**The earliest questions on a site will set the tone and topic of the site for a long time.**</blockquote>
+> **The earliest questions on a site will set the tone and topic of the site for a long time.**
 
 
 The AI site conspicuously lacked that "tone and topic" from day one, so it had nowhere to go and was closed down.

--- a/_posts/2011-01-04-welcome-valued-associate-nick-craver.markdown
+++ b/_posts/2011-01-04-welcome-valued-associate-nick-craver.markdown
@@ -29,21 +29,13 @@ Apparently Nick's membership to Stack Overflow predates even Jon Skeet's, but he
 
 
 
-<blockquote>
-Every day, my guild leader faced a decision: play WoW, or work toward becoming a paramedic. If she played WoW, she'd have fun, and advance a character or improve the guild in some small but measurable way. If she worked toward becoming a paramedic, her progress would be much less visible. It's easy to say that on any given day, the decision doesn't really matter. But every day spent on WoW drove her in circles, and every day spent studying paramedicine would have brought her one day closer to her goal. **And days add up, like it or not. We cannot stop them from doing so. What we can do is decide what they add up to.**
-
-> 
-> 
-I didn't want to look around one day and discover I'd turned into my guild leader, dreams on the horizon but unachieved because my days added up to nothing. The idea frightened and depressed me.
-
-> 
-> 
-So I quit. I quit hard enough that the way the game had pulled me in the last time wasn't an option anymore. And instead of spending an hour every day doing my daily quests in-game, I spent an hour every day doing "daily quests" in real life - I started working out. I started leveling my actual skills and stats.
-
-> 
-> 
--- [Doing My Dailies: Why I Quit WoW And Started Working Out](http://www.pixelpoppers.com/2010/12/doing-my-dailies-why-i-quit-wow-and.html)
-</blockquote>
+> Every day, my guild leader faced a decision: play WoW, or work toward becoming a paramedic. If she played WoW, she'd have fun, and advance a character or improve the guild in some small but measurable way. If she worked toward becoming a paramedic, her progress would be much less visible. It's easy to say that on any given day, the decision doesn't really matter. But every day spent on WoW drove her in circles, and every day spent studying paramedicine would have brought her one day closer to her goal. **And days add up, like it or not. We cannot stop them from doing so. What we can do is decide what they add up to.**
+>
+> I didn't want to look around one day and discover I'd turned into my guild leader, dreams on the horizon but unachieved because my days added up to nothing. The idea frightened and depressed me.
+>
+> So I quit. I quit hard enough that the way the game had pulled me in the last time wasn't an option anymore. And instead of spending an hour every day doing my daily quests in-game, I spent an hour every day doing "daily quests" in real life - I started working out. I started leveling my actual skills and stats.
+>
+> -- [Doing My Dailies: Why I Quit WoW And Started Working Out](http://www.pixelpoppers.com/2010/12/doing-my-dailies-why-i-quit-wow-and.html)
 
 
 

--- a/_posts/2011-12-02-the-best-of-blog-overflow-november-2011.markdown
+++ b/_posts/2011-12-02-the-best-of-blog-overflow-november-2011.markdown
@@ -37,9 +37,9 @@ I'm going to be honest: despite my math minor, I didn't fully grasp this entry. 
 This past month, the TeX (pronounced like "tech" for those unaware) blog [interviewed one of their top users](http://tex.blogoverflow.com/2011/11/textalk-an-interview-with-lockstep/), lockstep. The interview itself is long but really interesting; he talks about his vocation, his work with TeX, and why he uses our TeX site. It's absolutely worth a read, even if (La)TeX isn't necessarily immediate in your life.
 
 
-<blockquote>**Paulo:** As Joseph mentioned, you are the biblatex expert and the one-man tagging machine on TeX.sx. How did you become aware of this community? :)
+>**Paulo:** As Joseph mentioned, you are the biblatex expert and the one-man tagging machine on TeX.sx. How did you become aware of this community? :)
 
-**lockstep:** I occasionally peruse comp.text.tex via Google (I do not participate, though). There was a post about a proposed stackexchange group dealing with TeX, and (half a year later or so) another post that the private beta had started. I decided to give tex.sx a try – it was already in public beta then. The rest is history. ;-)</blockquote>
+> **lockstep:** I occasionally peruse comp.text.tex via Google (I do not participate, though). There was a post about a proposed stackexchange group dealing with TeX, and (half a year later or so) another post that the private beta had started. I decided to give tex.sx a try – it was already in public beta then. The rest is history. ;-)
 
 
 **[English Language & Usage](http://english.blogoverflow.com/)**


### PR DESCRIPTION
I individually inspected every Markdown file containing a `<blockquote>`
tag, and either:
- Ignored the post if there was no formatting and no paragraph breaks
  within the blockquote
- Changed the formatting to pure HTML tags if it was a single-paragraph
  blockquote (to avoid extra vertical space after the auto-generated `<p>`
  tags if it was a Markdown quote)
- Changed the `<blockquote>` tags to angle brackets

I have inspected the rendered output for each of the changed posts to
verify that the changes give the right result.

This doesn't cover every post with blockquotes - there are still some
with weird formatting that I haven't had time to get around to yet.

---

Related to issue #95 
