### PR TITLE
Fix blockquote formatting in more posts

### DIFF
--- a/_posts/2009-06-28-cmon-get-meta.markdown
+++ b/_posts/2009-06-28-cmon-get-meta.markdown
@@ -38,7 +38,7 @@ We have this policy not because we are jerks (or at least, not _just_ because we
 
 
 <blockquote>
-Also, try to **refrain from asking questions about Stack Overflow itself unless you absolutely, positively have to**. Most programmers don't come here to learn about the intricacies of Stack Overflow; they come here to get answers to their programming questions. Let's try to help them out by not cluttering up the system with navelgazing meta-discussion. If you want to suggest a feature or discuss how Stack Overflow works, visit our UserVoice site.
+Also, try to <strong>refrain from asking questions about Stack Overflow itself unless you absolutely, positively have to</strong>. Most programmers don't come here to learn about the intricacies of Stack Overflow; they come here to get answers to their programming questions. Let's try to help them out by not cluttering up the system with navelgazing meta-discussion. If you want to suggest a feature or discuss how Stack Overflow works, visit our UserVoice site.
 </blockquote>
 
 
@@ -51,7 +51,7 @@ Despite this rule, the desire for an "official" meta-discussion site has been st
 
 
 
-<blockquote>
+>
 I know this has been declined multiple times, but I really think it's time to consider the problem of meta-discussions on the site. To understand why something else is needed, let's look at what doesn't work:
 
 > 
@@ -72,7 +72,6 @@ I know this has been declined multiple times, but I really think it's time to co
 > 
 > 
 The current system completely cuts off meta-conversations to the detriment of the SO community.
-</blockquote>
 
 
 
@@ -145,7 +144,7 @@ Kyle had some ideas about changes to the SO engine to help it adapt from the Q&A
 
 
 
-<blockquote>
+>
 
 > 
 > 
@@ -163,7 +162,7 @@ Kyle had some ideas about changes to the SO engine to help it adapt from the Q&A
 >   * remove accepting an answer
 
 >   * some of the close reasons will have to be removed or tweaked
-</blockquote>
+
 
 
 

--- a/_posts/2009-07-06-are-you-a-human-being.markdown
+++ b/_posts/2009-07-06-are-you-a-human-being.markdown
@@ -19,7 +19,7 @@ Ever had one of these days?
 
 
 
-<blockquote>
+>
 **Are you a human being?**
 
 > 
@@ -41,7 +41,7 @@ Ever had one of these days?
 > Enter the [CAPTCHA](http://en.wikipedia.org/wiki/Captcha) displayed below, and we'll be out of your way.
 > 
 > 
-</blockquote>
+
 
 
 

--- a/_posts/2010-03-31-reminder-its-april-1st.markdown
+++ b/_posts/2010-03-31-reminder-its-april-1st.markdown
@@ -75,7 +75,7 @@ He's created so much cool stuff, in fact, the meta community took it upon themse
 
 
 
-<blockquote>
+>
 It has come to the attention of the AWESOME committee that you have recently exceeded your awesome quotient. Normally this letter would simply serve as a warning and reminder as to your obligations in the LEAGUE OF AWESOME with regards to your display of AWESOME, however **your recent display(s) of AWESOME have exceeded the limit beyond all normal care and due reason.**
 
 > 
@@ -85,7 +85,7 @@ It is with heavy hearts that we are forced to take the following, regrettable, d
 > 
 > 
 Mr. Balpha, on this day, March 31st, 2010, and henceforth, your membership in THE LEAGUE OF AWESOME is terminated, including all benefits, responsibilities, and services as described in your recently violated contract. You are hereby stricken from all records and are required to turn in your membership license or proof of its destruction. Also any and all other artifacts, including the LOA belt buckle, is to be returned immediately.
-</blockquote>
+
 
 
 

--- a/_posts/2010-04-13-changes-to-stack-exchange.markdown
+++ b/_posts/2010-04-13-changes-to-stack-exchange.markdown
@@ -93,26 +93,19 @@ Want to create a Stack Exchange community? Propose it! If your idea gets suffici
 
 
 <blockquote>
+<p>I’m just a bill.<br/>
+Yes, I’m only a bill.<br/>
+And I’m sitting here on Capitol Hill.<br/>
+Well, it’s a long, long journey<br/>
+To the capital city.<br/>
+It’s a long, long wait<br/>
+While I’m sitting in committee,<br/>
+But I know I’ll be a law someday<br/>
+At least I hope and pray that I will,<br/>
+But today I am still just a bill.</p>
 
-> 
-> 
-
-
-> 
-> 
-_I’m just a bill.
-Yes, I’m only a bill.
-And I’m sitting here on Capitol Hill.
-Well, it’s a long, long journey
-To the capital city.
-It’s a long, long wait
-While I’m sitting in committee,
-But I know I’ll be a law someday
-At least I hope and pray that I will,
-But today I am still just a bill.
-
-—I’m Just a Bill_
-(from Schoolhouse Rock)
+—I’m Just a Bill<br/>
+(from Schoolhouse Rock)<br/>
 Dave Frishberg</blockquote>
 
 

--- a/_posts/2010-07-10-the-7-essential-meta-questions-of-every-beta.markdown
+++ b/_posts/2010-07-10-the-7-essential-meta-questions-of-every-beta.markdown
@@ -67,10 +67,10 @@ But the questions you want to discuss in meta are those issues specific to your 
 Take [Super User's "About" page](http://superuser.com/about) as an example:
 
 
-<blockquote>Super User is for computer enthusiasts and power users.
- …
+>Super User is for computer enthusiasts and power users.
+> …
 
-Ask about...
+> Ask about...
 
 
 > 
@@ -82,7 +82,7 @@ Ask about...
 >   * Real problems or questions that you’ve encountered
 > 
 
-Don't ask about...
+> Don't ask about...
 
     
 >   * Anything not directly related to computer software or computer hardware
@@ -105,7 +105,7 @@ Don't ask about...
     
 >   * Issues specific to corporate IT support and networks
 > 
-</blockquote>
+>
 
 
 These are then elaborated on in SU's [What topics can I ask about here?](http://superuser.com/help/on-topic) page.

--- a/_posts/2010-08-01-tag-folksonomy-and-tag-synonyms.markdown
+++ b/_posts/2010-08-01-tag-folksonomy-and-tag-synonyms.markdown
@@ -36,20 +36,14 @@ As you can see, our fellow users have already contributed a nice little wiki for
 
 
 
-<blockquote>
-Tag wikis help introduce newcomers to the tag. They contain frequently asked questions about the tag and guidelines on its usage.
+> Tag wikis help introduce newcomers to the tag. They contain frequently asked questions about the tag and guidelines on its usage.
 
-Tag wikis can be edited by users with more than 2000 reputation, provided:
-
-
-> 
-> 
+> Tag wikis can be edited by users with more than 2000 reputation, provided:
 
 >   * They are in the top 20 answerers for this tag or
 
 >   * They have more than 100 answer upvotes in this tag
 
-</blockquote>
 
 
  

--- a/_posts/2010-08-07-the-death-of-meta-tags.markdown
+++ b/_posts/2010-08-07-the-death-of-meta-tags.markdown
@@ -42,7 +42,7 @@ There are some weak arguments in favor of keeping [subjective], but that's about
 
 
 
-<blockquote>
+>
 I think the [subjective] tag is useless at best and actively harmful at worst.
 
 > 
@@ -56,7 +56,7 @@ And harmful, because there are some users who actually believe that, like commun
 > 
 > 
 It's been used pejoratively and defensively, without any real consistency, for a long long time now. Time to go.
-</blockquote>
+
 
 
 
@@ -68,7 +68,7 @@ However, it wasn't until I saw [this absolutely brilliant post by Aaronut](http:
 
 
 
-<blockquote>
+>
 There's been a major uptick recently in tags that are not useful and just add noise. I want to stress that these are usually added in good faith, and I am not questioning anybody's motivation - I know that they all mean well. But this particular category of tags is one that has been historically referred to as meta-tags on MSO, and these tags cause a lot of problems.
 
 > 
@@ -78,7 +78,7 @@ There's been a major uptick recently in tags that are not useful and just add no
 > 
 > 
 Meta-tags are actually a subset of a larger problem that I usually call dependent tags. These are tags that don't say anything by themselves - you can't tell what the question is about unless they're paired with some other tag (or several of them). These tags are a problem because people don't realize this and will often use that as the question's only tag.
-</blockquote>
+
 
 
 

--- a/_posts/2010-08-11-defending-attribution-required.markdown
+++ b/_posts/2010-08-11-defending-attribution-required.markdown
@@ -22,7 +22,7 @@ What does this mean? In short, it's a way of **guaranteeing that we can't ever d
 We wouldn't want that done to us. And there's no way we're doing it to our community. To prove it, **we adopted a licensing scheme that makes it impossible for us to do anything even partially-quasi-evil with our community's content**. Namely, [cc-by-sa](http://creativecommons.org/licenses/by-sa/3.0/) (aka cc-wiki), which gives everyone the following rights to all Stack Exchange data:
 
 
-<blockquote>You are free:
+>You are free:
 
 > 
 > 
@@ -42,7 +42,6 @@ Under the following conditions:
 >   * **Share Alike** — If you alter, transform, or build upon this work, you may distribute the resulting work only under the same or similar license to this one.
 > 
 
-</blockquote>
 
 
 This isn't news, of course; it's explained on the footer of every web page we serve. And note that we explicitly _allow_ commercial usage -- after all, _we're_ a commercial entity, so it felt only sporting to allow others the same rights we enjoyed.
@@ -52,7 +51,7 @@ What _is_ news, is this: lately we're getting a lot of reports of sites repostin
 [What are our attribution requirements?](http://blog.stackoverflow.com/2009/06/attribution-required/)
 
 
-<blockquote>Let me clarify what we mean by attribution. If you republish this content, we **require** that you:
+>Let me clarify what we mean by attribution. If you republish this content, we **require** that you:
 
 > 
 > 
@@ -69,7 +68,7 @@ What _is_ news, is this: lately we're getting a lot of reports of sites repostin
 >   4. **Hyperlink each author name** directly back to their user profile page on the source site (e.g., http://stackoverflow.com/users/12345/username)
 > 
 
-By “directly”, I mean each hyperlink must point directly to our domain in standard HTML visible even with JavaScript disabled, and not use a tinyurl or any other form of obfuscation or redirection. Furthermore, the links must _not_ be [nofollowed](http://googleblog.blogspot.com/2005/01/preventing-comment-spam.html).</blockquote>
+> By “directly”, I mean each hyperlink must point directly to our domain in standard HTML visible even with JavaScript disabled, and not use a tinyurl or any other form of obfuscation or redirection. Furthermore, the links must _not_ be [nofollowed](http://googleblog.blogspot.com/2005/01/preventing-comment-spam.html).
 
 
 They're not complicated, nor are these attribution requirements particularly hard to find: they're linked from the footer of every web page we serve, and included as a plaintext file in every [public data dump we share](http://blog.stackoverflow.com/2009/06/stack-overflow-creative-commons-data-dump/).
@@ -87,11 +86,11 @@ I'm not going to stand for this, at least not without a fight. We're starting to
 And if they don't follow our simple attribution requirements when we've asked them nicely, well -- we're going to start asking them _not_ so nicely. Namely, we will hit them where it hurts, in the pocketbook. [Our pal How-to-Geek](http://www.howtogeek.com/) explains:
 
 
-<blockquote>For the quickest results, you can send the DMCA to their web host, which you can generally figure out with [whoishostingthis.com](http://whoishostingthis.com). Every single legit hosting center will have a "legal" or "copyright" page, and they will have a specific way to send in DMCA requests. Some of them require fax, though many are starting to accept email instead... and they will often have the content removed almost instantly. Wordpress.com will instantly cancel their entire account, and other hosts tend to take very swift action, often disabling their whole site until they comply.
+> For the quickest results, you can send the DMCA to their web host, which you can generally figure out with [whoishostingthis.com](http://whoishostingthis.com). Every single legit hosting center will have a "legal" or "copyright" page, and they will have a specific way to send in DMCA requests. Some of them require fax, though many are starting to accept email instead... and they will often have the content removed almost instantly. Wordpress.com will instantly cancel their entire account, and other hosts tend to take very swift action, often disabling their whole site until they comply.
 
-If you really want to cause them some pain, however, you can send the DMCA to their advertisers. Adsense is usually the first target for this, since so many of the jerks are using it. The only problem with Adsense is they [require a DMCA fax](http://www.google.com/adsense_dmca.html ).
+> If you really want to cause them some pain, however, you can send the DMCA to their advertisers. Adsense is usually the first target for this, since so many of the jerks are using it. The only problem with Adsense is they [require a DMCA fax](http://www.google.com/adsense_dmca.html ).
 
-There's been once or twice where I've found a site that was hosted somewhere that doesn't care about copyright... but every single ad network of any value is based in the US, and the jerk website owner isn't going to mess around with their income stream.</blockquote>
+> There's been once or twice where I've found a site that was hosted somewhere that doesn't care about copyright... but every single ad network of any value is based in the US, and the jerk website owner isn't going to mess around with their income stream.
 
 
 Please help us defend your right to have your name and source attached to the content you've so generously contributed to our sites. We will absolutely do our part, but many hands make light work:

--- a/_posts/2010-08-14-unix-and-ubuntu-why-both.markdown
+++ b/_posts/2010-08-14-unix-and-ubuntu-why-both.markdown
@@ -123,15 +123,15 @@ When it was clear that both the Unix and Ubuntu proposals were both moving forwa
 
 
 
-<blockquote>Dear Ubuntu Supporter,
+>Dear Ubuntu Supporter,
 
-We are about to launch the Area 51 proposal for "Ubuntu":
+> We are about to launch the Area 51 proposal for "Ubuntu":
 [area51.stackexchange.com/proposals/7716/ubuntu](http://area51.stackexchange.com/proposals/7716/ubuntu).
 
-But before we launch it, there has been a bit of discussion about whether members would be interested in merging it into a more generic Unix/Linux site. We are looking at whether more needs to be done to make sure the community is getting what they want or is the Ubuntu proposal ready to go as-is.
+> But before we launch it, there has been a bit of discussion about whether members would be interested in merging it into a more generic Unix/Linux site. We are looking at whether more needs to be done to make sure the community is getting what they want or is the Ubuntu proposal ready to go as-is.
 
-_Stack Exchange Team_
-</blockquote>
+> _Stack Exchange Team_
+
 
 
 
@@ -143,15 +143,15 @@ I'm paraphrasing...
 
 
 
-<blockquote>
+>
 Dear Stack Exchange Team,
 
-Ubuntu is an end-user operating system used by everyday people who are not typically interested in hacking around a kernel, nor configuring a large collection of tools, projects and packages, nor citing documentation references and command line arguments. The Linux proposal, in comparison, explicitly targets "advanced users," in which I have no interest. 
+> Ubuntu is an end-user operating system used by everyday people who are not typically interested in hacking around a kernel, nor configuring a large collection of tools, projects and packages, nor citing documentation references and command line arguments. The Linux proposal, in comparison, explicitly targets "advanced users," in which I have no interest.
 
-In short, we need our own space. Thank you.
+> In short, we need our own space. Thank you.
 
-_Ubuntu Supporter_
-</blockquote>
+> _Ubuntu Supporter_
+
 
 
 

--- a/_posts/2010-08-15-stack-exchange-api-contest-winners.markdown
+++ b/_posts/2010-08-15-stack-exchange-api-contest-winners.markdown
@@ -29,22 +29,19 @@ It was tough judging winners between so many fantastic entries. I  encourage you
 
 
 
-<blockquote>
+> We're awarding [Lilliput USB Monitors](http://www.thinkgeek.com/computing/usb-gadgets/c609/) to two members of the community who single-handedly contributed a huge number of apps and libraries to the contest.
 
-We're awarding [Lilliput USB Monitors](http://www.thinkgeek.com/computing/usb-gadgets/c609/) to two members of the community who single-handedly contributed a huge number of apps and libraries to the contest.
-
-**12** applications -- [SOAPI-Watch](http://stackapps.com/questions/534/soapi-watch-a-realtime-service-that-notifies-subscribers-via-twitter-when-the-ap), [SOAPI-Explore](http://stackapps.com/questions/603/soapi-explore-self-updating-single-page-javasript-api-test-harness) …
+> **12** applications -- [SOAPI-Watch](http://stackapps.com/questions/534/soapi-watch-a-realtime-service-that-notifies-subscribers-via-twitter-when-the-ap), [SOAPI-Explore](http://stackapps.com/questions/603/soapi-explore-self-updating-single-page-javasript-api-test-harness) …
 **2** libraries -- [Soapi.CS](http://stackapps.com/questions/386/soapi-cs-a-fully-relational-fluent-net-stack-exchange-api-client-library) and [Soapi.JS](http://stackapps.com/questions/494/soapi-js-v1-0-fluent-javascript-wrapper-for-the-stackoverflow-api)
 
-
-
-**9** applications -- [StackMobile.com](http://stackapps.com/questions/36/stackmobile-com-view-stackexchange-sites-on-your-smartphone), [StackApplet](http://stackapps.com/questions/83/stackapplet-stackoverflow-meets-the-gnome-desktop-v1-2-released), …
+> **9** applications -- [StackMobile.com](http://stackapps.com/questions/36/stackmobile-com-view-stackexchange-sites-on-your-smartphone), [StackApplet](http://stackapps.com/questions/83/stackapplet-stackoverflow-meets-the-gnome-desktop-v1-2-released), …
 **5** libraries -- [so++](http://stackapps.com/questions/25/so-c-library), [stack.PHP](http://stackapps.com/questions/826/stack-php-clean-easy-to-use-wrapper-for-php) …
 
 
 
-Kudos to **George Edison** and **code poet** for being such integral parts of the StackApps community.
-</blockquote>
+> Kudos to **George Edison** and **code poet** for being such integral parts of the StackApps community.
+
+
 
 
   
@@ -58,15 +55,14 @@ Kudos to **George Edison** and **code poet** for being such integral parts of th
 
 
 
-<blockquote>
+>
 **[Stacky - a .NET Client Library](http://stackapps.com/questions/6/stacky-a-net-client-library)**
 
-Stacky is a .Net client library for the Stack Apps API. It's a simple library supporting a variety of platforms such as Silverlight and Windows Phone 7, .NET 4 and .NET 3.5.
+> Stacky is a .Net client library for the Stack Apps API. It's a simple library supporting a variety of platforms such as Silverlight and Windows Phone 7, .NET 4 and .NET 3.5.
+
+> _adjustable height GeekDesk winner_
 
 
-
-_adjustable height GeekDesk winner_
-</blockquote>
 
 
   
@@ -80,17 +76,18 @@ _adjustable height GeekDesk winner_
 
 
 
-<blockquote>
+>
 **[Six to Eight : an iOS client](http://stackapps.com/questions/623/six-to-eight-an-iphone-client-now-in-the-app-store)**
 
-[![](http://blog.stackoverflow.com/wp-content/uploads/six-to-eight-screenshot.png)](http://stackapps.com/questions/623/six-to-eight-an-iphone-client-now-in-the-app-store)
+> [![](http://blog.stackoverflow.com/wp-content/uploads/six-to-eight-screenshot.png)](http://stackapps.com/questions/623/six-to-eight-an-iphone-client-now-in-the-app-store)
 
-Six to Eight is a free, pocket sized iOS client, for you to track your activity and get answers to those niggly, "need an answer right now" problems. Full browsing, searching, statistics and user tracking. [App Store link](http://itunes.apple.com/us/app/six-to-eight/id384094708?mt=8) (free)
+> Six to Eight is a free, pocket sized iOS client, for you to track your activity and get answers to those niggly, "need an answer right now" problems. Full browsing, searching, statistics and user tracking. [App Store link](http://itunes.apple.com/us/app/six-to-eight/id384094708?mt=8) (free)
 
 
 
-_CULV netbook winner_
-</blockquote>
+> _CULV netbook winner_
+
+
 
 
   
@@ -104,19 +101,20 @@ _CULV netbook winner_
 
 
 
-<blockquote>
+>
 **[StackPrinter: the Stack Exchange Printer Suite](http://stackapps.com/questions/179/stackprinter-the-stack-exchange-printer-suite)**
 
-[![](http://blog.stackoverflow.com/wp-content/uploads/stackprinter-screenshot.png)](http://stackapps.com/questions/179/stackprinter-the-stack-exchange-printer-suite)
+> [![](http://blog.stackoverflow.com/wp-content/uploads/stackprinter-screenshot.png)](http://stackapps.com/questions/179/stackprinter-the-stack-exchange-printer-suite)
 
-StackPrinter is a website that pulls the main details of a given question, all its answers, comments and votes formatting them in a simple essential printable view.
+> StackPrinter is a website that pulls the main details of a given question, all its answers, comments and votes formatting them in a simple essential printable view.
 
-I've created this micro web application basically to add a "Printer-Friendly" feature to the Stack Exchange Network sites, trying to remove some @Media Print CSS limitations like hidden comments, pagination and empty spaces.
+> I've created this micro web application basically to add a "Printer-Friendly" feature to the Stack Exchange Network sites, trying to remove some @Media Print CSS limitations like hidden comments, pagination and empty spaces.
 
 
 
-_Herman Miller Mirra chair winner_
-</blockquote>
+> _Herman Miller Mirra chair winner_
+
+
 
 
   
@@ -130,17 +128,17 @@ _Herman Miller Mirra chair winner_
 
 
 
-<blockquote>
+>
 **[StackTack, a Javascript widget you can stick anywhere](http://stackapps.com/questions/518/stacktack-a-javascript-widget-you-can-stick-anywhere)**
 
-[![](http://blog.stackoverflow.com/wp-content/uploads/stacktack-screenshot.png)](http://stackapps.com/questions/518/stacktack-a-javascript-widget-you-can-stick-anywhere)
+> [![](http://blog.stackoverflow.com/wp-content/uploads/stacktack-screenshot.png)](http://stackapps.com/questions/518/stacktack-a-javascript-widget-you-can-stick-anywhere)
 
-StackTack is a widget for bloggers and writers to easily tack questions and answers from the Stack Exchange sites such as Stack Overflow, Server Fault and Super User, into their articles. The widget remains up to date as answers get added, modified, voted on and accepted.
+> StackTack is a widget for bloggers and writers to easily tack questions and answers from the Stack Exchange sites such as Stack Overflow, Server Fault and Super User, into their articles. The widget remains up to date as answers get added, modified, voted on and accepted.
 
 
 
-_30" Dell or Apple LCD winner_
-</blockquote>
+> _30" Dell or Apple LCD winner_
+
 
 
   

--- a/_posts/2010-08-18-new-image-upload-support.markdown
+++ b/_posts/2010-08-18-new-image-upload-support.markdown
@@ -65,8 +65,8 @@ We're also using Imgur's [brand spanking new API](http://api.imgur.com/) to impl
 
 
 
-<blockquote>
 Ever since [Imgur accounts](http://imgur.com/register/upgrade) were released, people have been asking non-stop about the ability to upload into their accounts by using the tools. Your request did not go unheard. Today, I’m pleased to announce the new Imgur API, which not only includes support for uploading into accounts, but also includes support for managing every aspect of your account. 
+>
 
 > 
 > 
@@ -92,7 +92,7 @@ Here are just a few of the things you can do:
 > 
 > 
 Don’t worry if you’re a not a technical person and you don’t care about what an API is. What it means is that, very soon, you will have access to many more tools that enable you to upload into your account from your desktop, mobile phone, iPad, etc.
-</blockquote>
+
 
 
 

--- a/_posts/2010-08-20-should-unix-linux-and-ubuntu-be-merged-vote.markdown
+++ b/_posts/2010-08-20-should-unix-linux-and-ubuntu-be-merged-vote.markdown
@@ -19,7 +19,7 @@ Remember last week when we asked: [Unix and Ubuntu: Why Both?](http://blog.stack
 
 
 
-<blockquote>
+>
 
 > 
 > You may have noticed that two similar [Area 51](http://area51.stackexchange.com) site proposals have reached commitment and launched betas:
@@ -40,7 +40,7 @@ Remember last week when we asked: [Unix and Ubuntu: Why Both?](http://blog.stack
 > You might well ask: _aren't these the very same thing?_ Why have two communities on the same topic? What, then, is the difference between unix and ubuntu? The answer to this question cuts to the very heart of what community _is_.
 > 
 > 
-</blockquote>
+
 
 
 

--- a/_posts/2010-08-29-stack-overflow-sponsors-haproxy.markdown
+++ b/_posts/2010-08-29-stack-overflow-sponsors-haproxy.markdown
@@ -28,7 +28,7 @@ I'm pleased to announce that this new HAProxy feature we sponsored is [now avail
 
 
 
-<blockquote>
+>
 Geoff Dalgas and Jeff Atwood described to me in great details what they needed to do : perform request throttling per IP address, possibly based on various criteria, in order to limit risks of service abuse. That was very interesting, because that feature was being thought about for about 4 years without enough time to completely develop it …
 
 > 
@@ -38,7 +38,7 @@ Geoff Dalgas and Jeff Atwood described to me in great details what they needed t
 > 
 > 
 The last words naturally go to the really cool guys at Stack Overflow. It's very nice to see some sites and companies involve time and money and take risks to make Open Source products better. Of course they benefit from this work, but at no point during the whole development did they try to reduce the focus to their specific needs, quite the opposite. From the very first exchanges, their goal clearly was to make the product better, and that must be outlined. That's now achieved and I really appreciate their involvement. Thank you guys!
-</blockquote>
+
 
 
 

--- a/_posts/2010-09-02-fork-it.markdown
+++ b/_posts/2010-09-02-fork-it.markdown
@@ -34,9 +34,9 @@ When we opened up the process to allow the community to design their own sites, 
 Conclusion? There isn't a majority on both sides to merge. The Unix world loves to take sides. I don't have to blog about this; Freud already did, in 1930. He called it "the narcissism of minor differences":
 
 
+>
+It is clearly not easy for man to give up the satisfaction of this inclination to aggression.  They do not feel comfortable without it.  The advantage which a comparatively small cultural group offers of allowing this instinct an outlet in the form of hostility against intruders is not to be despised. It is always possible to bind together a considerable number of people in love, so long as there are other people left over to receive the manifestations of their aggressiveness.  I once discussed the phenomenon that is precisely communities with adjoining territories, and related to each other in other ways as well, who are engaged in constant feuds and in ridiculing each other -- like the Spaniards and Portuguese, for instance, the North Germans and South Germans, the English and Scotch, and so on.  I gave this phenomenon the name of "the narcissism of minor differences", a name which does not do much to explain it.  We can now see that it is a convenient and relatively harmless satisfaction of the inclination to aggression, by means of which cohesion between the members of the community is made easier.
 
-<blockquote>
-It is clearly not easy for man to give up the satisfaction of this inclination to aggression.  They do not feel comfortable without it.  The advantage which a comparatively small cultural group offers of allowing this instinct an outlet in the form of hostility against intruders is not to be despised. It is always possible to bind together a considerable number of people in love, so long as there are other people left over to receive the manifestations of their aggressiveness.  I once discussed the phenomenon that is precisely communities with adjoining territories, and related to each other in other ways as well, who are engaged in constant feuds and in ridiculing each other -- like the Spaniards and Portuguese, for instance, the North Germans and South Germans, the English and Scotch, and so on.  I gave this phenomenon the name of "the narcissism of minor differences", a name which does not do much to explain it.  We can now see that it is a convenient and relatively harmless satisfaction of the inclination to aggression, by means of which cohesion between the members of the community is made easier.  
   
 
 
@@ -44,7 +44,6 @@ It is clearly not easy for man to give up the satisfaction of this inclination t
 > [—Civilization and its Discontents](http://en.wikipedia.org/wiki/Civilization_and_Its_Discontents)
 > 
 > 
-</blockquote>
 
 
 
@@ -52,9 +51,9 @@ Monty Python might have put it better in [this scene (YouTube)](http://www.youtu
 
 
 
-<blockquote>
+>
 
-[![](http://blog.stackoverflow.com/wp-content/uploads/pfj.jpg)](http://www.youtube.com/watch?v=gb_qHP7VaZE)
+> [![](http://blog.stackoverflow.com/wp-content/uploads/pfj.jpg)](http://www.youtube.com/watch?v=gb_qHP7VaZE)
 
 
 > 
@@ -365,7 +364,6 @@ as much as anybody.
 > 
 > 
 
-</blockquote>
 
 
 

--- a/_posts/2010-09-14-pruning-season.markdown
+++ b/_posts/2010-09-14-pruning-season.markdown
@@ -26,11 +26,12 @@ First of all, because it's what we said we would do in [the original Stack Excha
 
 
 
-<blockquote>
+>
 **Why is the plan to close down sites that don’t get enough traffic?**
 
+>
 This harks back to our corporate goal to “make the Internet a better place to get expert answers to your questions.” A ghost town, without traffic, does not get people answers, but it does draw a few people away from other sites that might do so. We do not believe that the Internet benefits from putting up placeholder sites with negligible traffic that do not attract high quality communities. And we want the Stack Exchange brand to be synonymous with great community Q&A; sites, even if we don’t necessarily cover every topic under the sun.
-</blockquote>
+
 
 
 

--- a/_posts/2010-09-28-factionalism-site-or-tag.markdown
+++ b/_posts/2010-09-28-factionalism-site-or-tag.markdown
@@ -18,7 +18,7 @@ Let's say I told you we were going to create a programming website that **merged
 
 
 
-<blockquote>
+>
 I disagree with merging. I think [Java] should be a niche site that will attract the relatively expert crowd that doesn't usually care (or not as much) about other types of developer language questions. Yes, I'm talking specifically about myself, but also know about several others I know in the community who can speak for themselves if they wish.
 
 > 
@@ -28,7 +28,7 @@ By not merging it, we are giving a good one place to find answers only about [Ja
 > 
 > 
 It might sound superficial, but I think we're more likely to see the likes of [Java Expert #1] and [Java Expert #2] in a separate, unmerged [Java] site than in a broader developer site.
-</blockquote>
+
 
 
 
@@ -69,11 +69,12 @@ None of the example questions in the Developer Testing proposal lacks a home. Th
 
 
 
-<blockquote>
-**duplicate**  
+>
+**duplicate**
 
+>
 This proposal would tend to drain audience from another Stack Exchange site.
-</blockquote>
+
 
 
 

--- a/_posts/2010-09-29-good-subjective-bad-subjective.markdown
+++ b/_posts/2010-09-29-good-subjective-bad-subjective.markdown
@@ -19,11 +19,11 @@ Stack Exchange is about questions with objective, factual answers. We've been cr
 
 
 
-<blockquote>
+>
 **What kind of questions should I not ask here?**
 
+>
 Avoid asking questions that are subjective, argumentative, or require extended discussion. This is not a discussion board, this is a place for questions that can be answered!
-</blockquote>
 
 
 

--- a/_posts/2010-10-01-an-area-51-apology-and-clarification.markdown
+++ b/_posts/2010-10-01-an-area-51-apology-and-clarification.markdown
@@ -37,11 +37,11 @@ As Joel explained in [Merging Season](http://blog.stackoverflow.com/2010/09/merg
 
 
 
-<blockquote>
+>
 1. Almost all X questions are on-topic for site Y
 2. Y already exists, it already has a tag for X, and nobody is complaining
 3. There’s a high probability that users of site Y would enjoy seeing the occasional question about X
-</blockquote>
+
 
 
 

--- a/_posts/2010-10-05-domain-names-the-wrong-question.markdown
+++ b/_posts/2010-10-05-domain-names-the-wrong-question.markdown
@@ -49,11 +49,11 @@ On the upside, nothing makes me happier than knowing we have a large group of v
 Through all the confusion and arguments, one user came through with a rational and useful piece of feedback. It is deceptively simple:
 
 
-<blockquote>I have a feeling that the real heart of the issue is that everyone thinks **naming is hard**. That's not completely true, **the truth is finding a .com domain name for a matching good name is hard**...
+>I have a feeling that the real heart of the issue is that everyone thinks **naming is hard**. That's not completely true, **the truth is finding a .com domain name for a matching good name is hard**...
 
-Since finding a .com domain naming for a matching site name is so hard, perhaps the community should come up with a good name and later consider which types of domain names they can get for that name. Two distinct things, not one.** **
+> Since finding a .com domain naming for a matching site name is so hard, perhaps the community should come up with a good name and later consider which types of domain names they can get for that name. Two distinct things, not one.
 
-[Brian R. Bondy](http://meta.webapps.stackexchange.com/questions/624/webapps-stackexchange-com-versus-nothingtoinstall-com/672#672)</blockquote>
+> [Brian R. Bondy](http://meta.webapps.stackexchange.com/questions/624/webapps-stackexchange-com-versus-nothingtoinstall-com/672#672)
 
 
 It turns out, we, the supposed experts of all things Q&A, had made the most newbie mistake there is -- **we've been asking the wrong damn question all along!**

--- a/_posts/2010-10-08-search-all-stack-exchange-sites.markdown
+++ b/_posts/2010-10-08-search-all-stack-exchange-sites.markdown
@@ -23,11 +23,11 @@ The above document was last edited April 15th, 2008. Ah, memories...
 
 
 
-<blockquote>
+>
 Don't try to replace forums. Answer people's questions! That's our focus. Get those answers to the top of Google search so people can find the information they're looking for with a minimum of noise.
 
-How will people arrive at the site? **1) Google -- ideally directly to the question and answer.**
-</blockquote>
+> How will people arrive at the site? **1) Google -- ideally directly to the question and answer.**
+
 
 
 

--- a/_posts/2010-10-14-new-question-migration-paths.markdown
+++ b/_posts/2010-10-14-new-question-migration-paths.markdown
@@ -29,7 +29,7 @@ Why? Well, **sometimes questions are asked that _just don't belong_**. In the sp
 
 
 
-<blockquote>
+>
 **exact duplicate**
 This question covers exactly the same ground as earlier questions on this topic; its answers may be merged with another identical question.
 
@@ -40,15 +40,17 @@ Questions on Stack Overflow are expected to generally relate to programming or s
 > 
 > 
 
-**not constructive**
+>
+**not constructive**<br/>
 This question is not a good fit to our Q&A; format. We expect answers to generally involve facts, references, or specific expertise; this question will likely solicit opinion, debate, arguments, polling, or extended discussion.
 
-**not a real question**
+>
+**not a real question**<br/>
 It's difficult to tell what is being asked here. This question is ambiguous, vague, incomplete, overly broad, or rhetorical and cannot be reasonably answered in its current form.
 
-**too localized**
+>
+**too localized**<br/>
 This question would only be relevant to a small geographic area, a specific moment in time, or an extraordinarily narrow situation that is not generally applicable to the worldwide audience of the internet.
-</blockquote>
 
 
 

--- a/_posts/2010-10-15-stack-overflow-chat-now-live.markdown
+++ b/_posts/2010-10-15-stack-overflow-chat-now-live.markdown
@@ -17,11 +17,12 @@ It seems like only [five short months ago](http://blog.stackoverflow.com/2010/04
 
 
 
-<blockquote>
+>
 The third place is a term used in the concept of community building to refer to social surroundings separate from the two usual social environments of **home** and the **workplace**. In his influential book The Great Good Place, Ray Oldenburg argues that **third places** are important for civil society, democracy, civic engagement, and establishing feelings of a sense of place.
 
+>
 Most needed are those [‘third places’](http://en.wikipedia.org/wiki/Third_place) which lend a public balance to the increased privatization of home life. Third places are nothing more than informal public gathering places. The phrase ‘third places’ derives from considering our homes to be the ‘first’ places in our lives, and our work places the ‘second.’
-</blockquote>
+
 
 
 

--- a/_posts/2010-10-19-vote-early-vote-often.markdown
+++ b/_posts/2010-10-19-vote-early-vote-often.markdown
@@ -98,14 +98,14 @@ These new voting badges will be applied retroactively, and complement the existi
 
 
 
-<blockquote>
+>
 Let each citizen remember at the moment he is offering his vote that he is not making a present or a compliment to please an individual -- or at least that he ought not so to do; but that he is executing one of the most solemn trusts in human society.
 
 > 
 > - Samuel Adams
 > 
 > 
-</blockquote>
+
 
 
 

--- a/_posts/2010-10-21-when-will-my-site-graduate.markdown
+++ b/_posts/2010-10-21-when-will-my-site-graduate.markdown
@@ -20,7 +20,7 @@ At 90 days into beta, we're supposed to evaluate each Area 51 beta site and eith
 
 
 
-<blockquote>
+>
 
 > 
 > ## Please do not close GIS SE
@@ -44,7 +44,7 @@ At 90 days into beta, we're supposed to evaluate each Area 51 beta site and eith
 > **Please don't!** We may be small, but we're good and growing. I've been working in the GIS field for almost 15 years and been active on every applicable BBS, mailing list, online forum and wiki for that time. I can honestly state that GIS SE has something that all those others didn't, and that something is valuable and worth nurturing. Give us some more time, please. Thanks.
 > 
 > 
-</blockquote>
+
 
 
 
@@ -249,7 +249,7 @@ If the site _needs_ interim reputation levels, that is a strong indication that 
 
 
 
-<blockquote>... it would just be yet another beta stage on top of the private and public betas. We don't need 4 beta stages. **If the site is going to graduate, it needs to graduate. **Perhaps basing graduation off of number of users at the different rep levels instead of a hard 90 days would be a better indication of a community's ability to self-police and readiness to be a real site. — [rchern](http://meta.stackoverflow.com/questions/67054/can-we-grandfather-in-rep-abilities-as-sites-leave-beta/67057#67057) (webapps moderator)</blockquote>
+<blockquote>... it would just be yet another beta stage on top of the private and public betas. We don't need 4 beta stages. **If the site is going to graduate, it needs to graduate. **Perhaps basing graduation off of number of users at the different rep levels instead of a hard 90 days would be a better indication of a community's ability to self-police and readiness to be a real site. — <a href="http://meta.stackoverflow.com/questions/67054/can-we-grandfather-in-rep-abilities-as-sites-leave-beta/67057#67057">rchern</a> (webapps moderator)</blockquote>
 
 
 

--- a/_posts/2010-11-03-the-horror-of-no-answer-revival-and-necromancer.markdown
+++ b/_posts/2010-11-03-the-horror-of-no-answer-revival-and-necromancer.markdown
@@ -22,13 +22,13 @@ However, we have noticed a sizable uptick in the number of questions that have n
 
 
 
-<blockquote>
-Questions asked more than **30** days ago with no answers:
+>
+Questions asked more than **30** days ago with no answers:<br/>
 64k / 1m+
 
-Questions asked more than **120** days ago with no answers:
+>
+Questions asked more than **120** days ago with no answers:<br/>
 40k / 1m+
-</blockquote>
 
 
  

--- a/_posts/2010-11-09-stack-overflow-homepage-changes.markdown
+++ b/_posts/2010-11-09-stack-overflow-homepage-changes.markdown
@@ -18,11 +18,10 @@ As I mentioned in [The Horror of No Answer: Revival and Necromancer](http://blog
 
 
 
-<blockquote>
-It’s fine — expected, even — for there to be a “long tail” of questions that are too obscure, too narrow, or just plain unanswerable for whatever reason. Sometimes you have to be patient; it takes the time it takes. But seeing the number of zero-answer questions grow by 50% over a 3 month period is definitely concerning.
+> It’s fine — expected, even — for there to be a “long tail” of questions that are too obscure, too narrow, or just plain unanswerable for whatever reason. Sometimes you have to be patient; it takes the time it takes. But seeing the number of zero-answer questions grow by 50% over a 3 month period is definitely concerning.
 
-Part of this is our fault for not adapting the homepage to the massive amount of question activity that Stack Overflow now enjoys. We’re working on it, but it will take some time to figure out the right approach.
-</blockquote>
+> Part of this is our fault for not adapting the homepage to the massive amount of question activity that Stack Overflow now enjoys. We’re working on it, but it will take some time to figure out the right approach.
+
 
 
 

--- a/_posts/2010-11-23-qa-is-hard-lets-go-shopping.markdown
+++ b/_posts/2010-11-23-qa-is-hard-lets-go-shopping.markdown
@@ -25,10 +25,10 @@ However, as we launched [the great Super User experiment](http://superuser.com/)
 That is, on [Super User](http://superuser.com/) we began encountering questions like:
 
 
-<blockquote>Macbook Air vs. Macbook Pro?
-What's the best dual-band wireless router?
-Dell GX280 Processor upgrade?
-What RAM should I buy?
+<blockquote>Macbook Air vs. Macbook Pro?<br/>
+What's the best dual-band wireless router?<br/>
+Dell GX280 Processor upgrade?<br/>
+What RAM should I buy?<br/>
 Nvidia or ATI video card?</blockquote>
 
 
@@ -55,7 +55,7 @@ These questions may seem tolerable at first glance. Isn't it our mandate to help
 Let's say the question asker provided all that information. Fat chance, I know, but let's pretend for a moment they did -- and we were able to provide the _perfect, ideal shopping recommendation_ to them. Even if that was the case, technology moves so rapidly that **the best shopping recommendations will be utterly obsolete within a year!** What's the point of a bunch of labor intensive questions that provide only temporary benefit to a limited (some might say Too Localized) audience? There isn't any. That's what we concluded, and we [explicitly disallowed](http://meta.superuser.com/questions/1103/should-we-add-a-no-shopping-recommendation-clause-to-the-super-user-faq) shopping questions in the [Super User FAQ](http://superuser.com/faq):
 
 
-<blockquote>Super User is for computer enthusiasts and power users. If you have a question about …
+>Super User is for computer enthusiasts and power users. If you have a question about …
 
 > 
 > 
@@ -66,6 +66,7 @@ Let's say the question asker provided all that information. Fat chance, I know, 
 >   * computer software
 > 
 
+>
 and it is **not about** …
 
 > 
@@ -83,7 +84,7 @@ and it is **not about** …
 >   * a shopping or buying recommendation 
 > 
 
-… then you're in the right place to ask your question!</blockquote>
+… then you're in the right place to ask your question!
 
 
 
@@ -93,16 +94,18 @@ and it is **not about** …
 Here's one way to ask:
 
 
-<blockquote>**Q: What's the best low light point-and-shoot camera?**
+>**Q: What's the best low light point-and-shoot camera?**
 
-A: Canon S90 and Lumix LX3.</blockquote>
+>
+A: Canon S90 and Lumix LX3.
 
 
 Here's [another way](http://photo.stackexchange.com/questions/1373/what-point-and-shoots-are-good-in-low-light-conditions) to ask:
 
 
-<blockquote>**Q: How do I tell which point-and-shoot cameras take good low light photos?**
+>**Q: How do I tell which point-and-shoot cameras take good low light photos?**
 
+>
 A: I strongly recommend looking for something with
 
 > 
@@ -117,7 +120,8 @@ A: I strongly recommend looking for something with
 >   * the biggest sensor available
 > 
 
-The sum of these factors are really critical for low light situations.</blockquote>
+>
+The sum of these factors are really critical for low light situations.
 
 
 The former question provides the path of least resistance: a laundry list of products I can buy without thinking about it too much. But that answer will only be valid for a year at best. The latter question may take some thinking, but its answer will be valid _forever_ … or at least until camera technology somehow shifts beyond lenses and sensors as we know them today. Thus, when it comes to shopping questions, don't ask us what you should buy -- ask us _what you need to learn_ to tell what you should buy.

--- a/_posts/2010-11-29-the-pee-wee-herman-rule.markdown
+++ b/_posts/2010-11-29-the-pee-wee-herman-rule.markdown
@@ -23,7 +23,7 @@ I recently had a [long discussion](http://meta.gaming.stackexchange.com/question
 
 
 <blockquote>
-If we get an excellent user who asks a _good, thoughtful_ [game] identification question and sticks around in our community to participate, then it's worth allowing it in those rare cases as a high quality "getting to know you" fun question.
+If we get an excellent user who asks a <em>good, thoughtful</em> [game] identification question and sticks around in our community to participate, then it's worth allowing it in those rare cases as a high quality "getting to know you" fun question.
 </blockquote>
 
 
@@ -61,31 +61,39 @@ That's why I recommend considering these gray area questions in the context of t
 
 
 
-<blockquote>
+>
 [Pee-Wee Herman walks into a noisy, rowdy, crowded biker bar. He puts a coin in the pay phone and begins dialing.]
 
-Pee-Wee: 
+>
+Pee-Wee:
 What? I'm sorry, operator. I can't hear you. [turns to the bikers, yelling in exaggerated fashion] _Shhh!_ I'm _trying_ to use the phone!
 
-[The bikers all grow quiet and circle around Pee-Wee at the pay phone. The lead biker hangs up the phone.]   
-                   
+>
+[The bikers all grow quiet and circle around Pee-Wee at the pay phone. The lead biker hangs up the phone.]
+
+>
 Biker:
 Did anybody tell you that this is the private club of the Satan's Helpers?
                    
+>
 Pee-Wee:
 Nobody hipped me to that, dude!   
                    
+>
 Biker:
 It's off-limits!
            
+>
 Pee-Wee:
 Oh. Well, _my mistake_. Ha ha! Guess I'll be on my way, then! Ha ha!
 
+>
 [Pee-Wee tries to innocently exit, pushing his way gently outward against the tightly grouped circle of bikers surrounding him.]
 
+>
 Pee-Wee:
 Excuse me! Excuse me. Ha ha! _Excuse_ me! Excuse me.
-</blockquote>
+
 
 
 

--- a/_posts/2010-12-02-stack-exchange-moderator-elections-begin.markdown
+++ b/_posts/2010-12-02-stack-exchange-moderator-elections-begin.markdown
@@ -22,7 +22,7 @@ Our fellow [moderators Pro Tempore](http://blog.stackoverflow.com/2010/07/modera
 
 
 <blockquote>
-We don't run Stack Overflow. _You_ do.
+We don't run Stack Overflow. <em>You</em> do.
 </blockquote>
 
 

--- a/_posts/2010-12-13-re-launching-stack-exchange-data-explorer.markdown
+++ b/_posts/2010-12-13-re-launching-stack-exchange-data-explorer.markdown
@@ -30,7 +30,7 @@ If you're wondering what the heck this thing is, do [read the introductory blog 
 
 
 <blockquote>
-Stack Exchange Data Explorer is **a web tool for sharing, querying, and analyzing the Creative Commons data from every website in the Stack Exchange network**. It's also useful as for learning SQL and sharing SQL queries as a 'reference database'.
+Stack Exchange Data Explorer is <strong>a web tool for sharing, querying, and analyzing the Creative Commons data from every website in the Stack Exchange network</strong>. It's also useful as for learning SQL and sharing SQL queries as a 'reference database'.
 </blockquote>
 
 
@@ -41,19 +41,23 @@ Mostly because we decided to move off the [Windows Azure](http://www.microsoft.c
 
 
 
-<blockquote>
+>
 
 > 
 > ## Teething issues
 > 
 > 
 
+>
 When we first started working with Azure, tooling was very rough. Tooling for Visual Studio and .NET 4.0 support only appeared a month after we started development. [Remote access to Azure instances](http://msdn.microsoft.com/en-us/library/gg443832.aspx) was only granted a few weeks ago together with the ability to run non-user processes.
 
+>
 There are still plenty of teething issues left, for example: on the SQL Azure side we can't run cross database queries, add full-text indexes or backup our dbs using the `BACKUP` command. I am sure these will eventually be worked out. There's also the 30 minute deploy cycle. Found a typo on the website? Correcting it is going to take 30 minutes, minimum.
 
+>
 Due to many of these teething issues, debugging problems with our Azure instances quickly became a nightmare. I spent days trying to work out why we were having uptime issues, which since have been mostly sorted.
 
+>
 It is important to note that these issues are by no means specific to Azure; **similar teething issues affect other Platform-As-A-Service providers** such as [Google App Engine](http://aralbalkan.com/1504) and [Heroku](http://heroku.com/). When you are using a PAAS you are giving up a lot of control to the service provider. The service provider chooses which applications you can run and imposes a series of restrictions.
 
 
@@ -62,8 +66,10 @@ It is important to note that these issues are by no means specific to Azure; **s
 > 
 > 
 
+>
 Whenever there is a new data dump, I would log on to my Rackspace instance, download the data dump, decompress it, rename a bunch of folders, run [my database importer](https://github.com/SamSaffron/So-Slow), and wait an hour for it to load. If there were any new sites, I would open up a SQL window and hack that into the DB. This process was time consuming and fairly tricky to automate. It could be automated, but it would require lots of work from our side.
 
+>
 Now that we migrated to servers we control, the process is almost simple -- all we do is select a bunch of data from export views (containing public data) and insert them into a fresh DB. We are not stuck coordinating work between 4 machines across 3 different geographical locations.
 
 
@@ -72,10 +78,11 @@ Now that we migrated to servers we control, the process is almost simple -- all 
 > 
 > 
 
+>
 At Stack Overflow [we take pride in our servers](http://blog.serverfault.com/). We spend weeks tweaking our hardware and software to ensure we get the best performance and in turn you, the end user, get the most awesome experience.
 
+>
 It was disorienting moving to a platform where we had no idea what kind of hardware was running our app. Giving up control of basic tools and processes we use to tune our environment was extremely painful.
-</blockquote>
 
 
 

--- a/_posts/2010-12-17-introducing-programmers-stackexchange-com.markdown
+++ b/_posts/2010-12-17-introducing-programmers-stackexchange-com.markdown
@@ -45,9 +45,10 @@ Remember, these are just guidelines, not hard and fast arbitrary rules; refer to
 
 
 
-<blockquote>
+>
 Programmers - Stack Exchange is for expert programmers who are interested in subjective discussions on software development.
 
+>
 This can include topics such as:
 
 
@@ -72,7 +73,7 @@ This can include topics such as:
 
 >   * Freelancing and business concerns
 
-</blockquote>
+
 
 
 

--- a/_posts/2011-01-08-how-to-say-thanks-in-an-answer.markdown
+++ b/_posts/2011-01-08-how-to-say-thanks-in-an-answer.markdown
@@ -36,13 +36,12 @@ Based on our experience with "thanks" answers, we knew that very short answers w
 
 
 
-<blockquote>
+>
 Long but mistaken arguments [on Hacker News] are actually quite rare. **There is a strong correlation between comment quality and length**; if you wanted to compare the quality of comments on community sites, average length would be a good predictor. Probably the cause is human nature rather than anything specific to comment threads. Probably it's simply that stupidity more often takes the form of having few ideas than wrong ones.
 
 > 
 > 
-Whatever the cause, stupid comments tend to be short. And since it's hard to write a short comment that's distinguished for the amount of information it conveys, people try to distinguish them instead by being funny. 
-</blockquote>
+Whatever the cause, stupid comments tend to be short. And since it's hard to write a short comment that's distinguished for the amount of information it conveys, people try to distinguish them instead by being funny.
 
 
 

--- a/_posts/2011-01-14-improved-flagging.markdown
+++ b/_posts/2011-01-14-improved-flagging.markdown
@@ -30,19 +30,22 @@ Clicking each option expands some explanatory text that provides context:
 
 
 
-<blockquote>
-**it needs ♦ moderator attention**
+> **it needs ♦ moderator attention**<br/>
+>
 A few canned common reasons, including "low quality", "not an answer" (for answers), and a 500 character (expanded from 150 characters) area for anything else you'd like to let the moderators know about.
 
-**it doesn't belong here**
+> **it doesn't belong here**<br/>
+>
 (generate a mod flag using [any existing close reason](http://blog.stackoverflow.com/2010/10/new-question-migration-paths/) as a template)
 
-**it is spam**
+> **it is spam**<br/>
+>
 This question is effectively an advertisement with no disclosure. It is not useful or relevant, but promotional.
 
-**it is not welcome in our community**
+> **it is not welcome in our community**<br/>
+>
 This question contains content that a reasonable person would consider offensive, abusive, or hate speech.
-</blockquote>
+
 
 
 
@@ -54,11 +57,12 @@ Another change we've instituted, [based on the popular Newgrounds flash game por
 
 
 
-<blockquote>
+>
 Due to the large amount of abuse to Newgrounds by malicious users we have implemented features that allow users to help police the site. A user's Whistle level can go up or down depending on how accurately the user flags questionable content. If a user abuses their use of the whistle to flag portal entries and reviews that do not violate our terms they will lose points and eventually be stuck with a broken whistle.
 
+>
 Users with broken whistles have no effect on anything they attempt to flag. However, users with a broken whistle may still receive negative or positive points so they can either dig themselves a deeper hole or try to regain a normal level and effectively flag entries once again. Users who blow the whistle accurately many times can increase their whistle level to bronze, silver, gold or deity levels. Users with a higher whistle level pull more weight when they use it.
-</blockquote>
+
 
 
 

--- a/_posts/2011-01-17-real-questions-have-answers.markdown
+++ b/_posts/2011-01-17-real-questions-have-answers.markdown
@@ -19,7 +19,7 @@ In [Good Subjective, Bad Subjective](http://blog.stackoverflow.com/2010/09/good-
 
 
 
-<blockquote>
+>
 Constructive subjective questions:
 
 
@@ -38,7 +38,7 @@ Constructive subjective questions:
 
 >   6. are more than just mindless social fun.
 
-</blockquote>
+
 
 
 
@@ -48,7 +48,7 @@ That was before I saw [Aarobot's epic meta answer on poll questions](http://meta
 
 
 
-<blockquote>
+>
 
 > 
 > **Should all poll questions be closed?** That is where it starts to get dicey.  For you see, the term "poll" is itself subjective, and whether or not a given question is in fact a poll is often open to debate.
@@ -75,8 +75,8 @@ That was before I saw [Aarobot's epic meta answer on poll questions](http://meta
  
 
 > 
-> Recently I've actually taken to using [Metafilter's guidelines](http://faq.metafilter.com/tags/chatfilter) as a rule of thumb. 
-</blockquote>
+
+> Recently I've actually taken to using [Metafilter's guidelines](http://faq.metafilter.com/tags/chatfilter) as a rule of thumb.
 
 
 
@@ -90,7 +90,6 @@ I'm just kicking myself for not discovering the particular page Aarobot referenc
 
 
 
-<blockquote>
 
 > 
 > ## What kind of questions should I _not_ ask here?
@@ -99,11 +98,10 @@ I'm just kicking myself for not discovering the particular page Aarobot referenc
 
 > 
 > 
-    You should only ask practical, answerable questions based on actual problems that you face. Chatty, open-ended questions diminish the usefulness of our site and push other questions off the front page. To prevent your question from being flagged and possibly removed, **avoid** asking subjective questions where …
     
 > 
 > 
-        
+  You should only ask practical, answerable questions based on actual problems that you face. Chatty, open-ended questions diminish the usefulness of our site and push other questions off the front page. To prevent your question from being flagged and possibly removed, **avoid** asking subjective questions where …
 >   * every answer is equally valid: "What's your favorite ______?"
 > 
         
@@ -129,7 +127,6 @@ If your motivation for asking the question is "I would like to participate in a 
 
 > 
 > 
-</blockquote>
 
 
 

--- a/_posts/2011-02-10-community-conference-sponsorships.markdown
+++ b/_posts/2011-02-10-community-conference-sponsorships.markdown
@@ -19,7 +19,7 @@ In [A Recipe to Promote your Site](http://blog.stackoverflow.com/2010/08/a-recip
 
 
 
-<blockquote>
+>
 
 > 
 > Any community that shows sufficient effort and innovative ideas to promote their site will be offered a budget and resources to make those ideas happen. Think of it as matching funds -- except we're matching effort, innovation, resources, and ideas from the community. And it _has_ to come from within your community. You're the experts, not us!
@@ -32,7 +32,6 @@ In [A Recipe to Promote your Site](http://blog.stackoverflow.com/2010/08/a-recip
 
 > 
 > 
-</blockquote>
 
 
 

--- a/_posts/2011-02-22-are-some-questions-too-simple.markdown
+++ b/_posts/2011-02-22-are-some-questions-too-simple.markdown
@@ -20,7 +20,7 @@ On [Podcast #58](http://blog.stackoverflow.com/2009/06/podcast-58/), Joel and I 
 
 
 <blockquote>
-Joel says that the only bad simple question is a duplicate simple question. I say simple questions are OK as long as they’re actually interesting (in some way) for other users to consider and answer. To prove his point, Joel actually asks the question on Stack Overflow: [How do I move the turtle in LOGO?](http://stackoverflow.com/questions/1003841/how-do-i-move-the-turtle-in-logo) Do _you_ think this question adds value?
+Joel says that the only bad simple question is a duplicate simple question. I say simple questions are OK as long as they’re actually interesting (in some way) for other users to consider and answer. To prove his point, Joel actually asks the question on Stack Overflow: <a href="http://stackoverflow.com/questions/1003841/how-do-i-move-the-turtle-in-logo">How do I move the turtle in LOGO?</a> Do <em>you<em> think this question adds value?
 </blockquote>
 
 
@@ -49,7 +49,7 @@ The problem is coming up enough in the network that we're thinking about adding 
 
 
 <blockquote>
-**General reference**: this question is too basic; the answer is indexed in any number of general internet reference sources designed specifically to find that type of information.
+<strong>General reference</strong>: this question is too basic; the answer is indexed in any number of general internet reference sources designed specifically to find that type of information.
 </blockquote>
 
 

--- a/_posts/2011-03-07-stack-overflow-and-the-computer-history-museum.markdown
+++ b/_posts/2011-03-07-stack-overflow-and-the-computer-history-museum.markdown
@@ -29,19 +29,15 @@ But we were on a toddler schedule, so we had to rush a bit. We took tons of phot
 
 
 
-<blockquote>
-stackoverflow.com  
+>
+stackoverflow.com
 
-Dedicated to the  
+> Dedicated to the <br/>
+> expert programmers <br/>
+> whose tireless work <br/>
+> made this plaque <br/>
+> possible
 
-expert programmers  
-
-whose tireless work  
-
-made this plaque  
-
-possible
-</blockquote>
 
 
 

--- a/_posts/2011-04-12-stack-exchange-partners-with-mathjax.markdown
+++ b/_posts/2011-04-12-stack-exchange-partners-with-mathjax.markdown
@@ -24,25 +24,30 @@ We love MathJax, and we use it on six sites in [the Stack Exchange network](http
 
 
 
-<blockquote>
+>
 **[Quantitative Finance](http://quant.stackexchange.com/)**
 Q&A; for finance professionals and academics
 
+>
 **[Electronics Design](http://electronics.stackexchange.com/)**
 Q&A; for electronic hardware hacking enthusiasts
 
+>
 **[Statistical Analysis](http://stats.stackexchange.com/)**
 Q&A; for statisticians, data analysts, data miners and data visualization experts
 
+>
 **[Physics](http://physics.stackexchange.com/)**
 Q&A; for active researchers, academics and students of physics
 
+>
 **[Mathematics](http://math.stackexchange.com/)**
 Q&A; for people studying math at any level and professionals in related fields
 
+>
 **[Theoretical Computer Science](http://cstheory.stackexchange.com/)**
 Q&A; for theoretical computer scientists and researchers in related fields
-</blockquote>
+
 
 
 

--- a/_posts/2011-05-06-vote-for-this-question-or-the-kitten-gets-it.markdown
+++ b/_posts/2011-05-06-vote-for-this-question-or-the-kitten-gets-it.markdown
@@ -21,13 +21,13 @@ When the wordpress.stackexchange.com community asked [Why are questions not bein
 
 
 
-<blockquote>
+>
 I have noticed a trend that questions (even good ones) that have multiple answers are not being voted on.
 
 > 
 > 
 Out of our 5,550 questions only 41% have at least 1 vote which leaves around 3,000 with 0 votes and a few hundred with negative votes.
-</blockquote>
+
 
 
 

--- a/_posts/2011-05-13-sponsoring-lucene-net-logo-design-contest.markdown
+++ b/_posts/2011-05-13-sponsoring-lucene-net-logo-design-contest.markdown
@@ -19,7 +19,7 @@ We are also big fans of the Lucene.Net project, which has [had some rocky times 
 
 
 
-<blockquote>
+>
 We'd love to take advantage of your offer for help. I've been trying to think of the most awesome thing that Stack Overflow could do for us, and I think I've finally found it.
 
 > 
@@ -33,7 +33,7 @@ We've been debating the logo used by Lucene.Net, which all agree is terrible. We
 > 
 > 
 So, what I ask of Stack Overflow, is to host, promote, manage, and pay for our logo design contest exactly as if it was a design contest for your company's products. Would this be a reasonable request?
-</blockquote>
+
 
 
 

--- a/_posts/2011-05-27-stack-exchange-is-an-openid-provider.markdown
+++ b/_posts/2011-05-27-stack-exchange-is-an-openid-provider.markdown
@@ -30,9 +30,10 @@ And best of all, it's a valid [Internet Driver's License](http://www.codinghorro
 
 
 
-<blockquote>
+>
   Once you create your Stack Exchange account you can use it to log in on thousands of websites.
-  
+
+>
   To log in to a [Stack Exchange site](http://stackexchange.com/sites):
   
   
@@ -42,7 +43,8 @@ And best of all, it's a valid [Internet Driver's License](http://www.codinghorro
 >   * click the 'Log in with Stack Exchange' button.
 > 
   
-  
+>
+>
   To log in to other websites that accept OpenID:
   
   
@@ -50,7 +52,7 @@ And best of all, it's a valid [Internet Driver's License](http://www.codinghorro
 >   * enter this URL [https://openid.stackexchange.com/](https://openid.stackexchange.com/)
 > 
   
-</blockquote>
+
 
 
 

--- a/_posts/2011-06-13-optimizing-for-pearls-not-sand.markdown
+++ b/_posts/2011-06-13-optimizing-for-pearls-not-sand.markdown
@@ -18,11 +18,11 @@ In March 2010, we [rebalanced our reputation system](http://blog.stackoverflow.c
 
 
 
-<blockquote>
-While we value good questions (and asking a great question is absolutely an art), we want to explicitly encourage people to provide the _best possible answers_. Without people interested in providing good answers, the questions are moot. We know that answers have more intrinsic value than questions, and the reputation balance should reflect that.
+> While we value good questions (and asking a great question is absolutely an art), we want to explicitly encourage people to provide the _best possible answers_. Without people interested in providing good answers, the questions are moot. We know that answers have more intrinsic value than questions, and the reputation balance should reflect that.
 
+>
 The question asker already enjoys a substantial benefit beyond reputation gain from upvotes on their question — namely, they get _great answers to their question!_ Thus, the asker shouldn’t need as much reputation gain.
-</blockquote>
+
 
 
 
@@ -31,7 +31,7 @@ In November 2010, we began to [actively block low quality questions](http://blog
 
 
 <blockquote>
-We believe asking questions on our site is a privilege, not a right. If, after a few fair attempts, you haven’t been able to prove that your contributions to a particular Stack Exchange make it at least … _not-worse_ … then we reserve the right to refuse your questions. If we don’t do our part to cull the bad questions, then we risk alienating the true experts who provide what really matters: the answers!
+We believe asking questions on our site is a privilege, not a right. If, after a few fair attempts, you haven’t been able to prove that your contributions to a particular Stack Exchange make it at least … <em>not-worse</em> … then we reserve the right to refuse your questions. If we don’t do our part to cull the bad questions, then we risk alienating the true experts who provide what really matters: the answers!
 </blockquote>
 
 
@@ -69,13 +69,15 @@ That's why we're determined to keep question quality high, even at the cost of r
 
 
 
-<blockquote>
+>
 To put it another way, when I go to a Stack Exchange home page, I see a **list of questions**. If most of those are terrible questions with little to no indication that I'd be wasting my time by reading them, the value proposition of visiting and participating is diminished: I have better things to do.
 
+>
 Compare that to _answers_ on a specific question: I've made a conscious choice to look into what I think is an interesting question. I already made the decision that the question is worth my time. If I find the answers to be useless, I have a few different options, as an interested party, to register my displeasure, including writing my own answer. Being able to write your own answer is key: if your answer is good enough, it'll rise above the junk answers and everyone will be better off for it.
 
+>
 There is no such action for question lists. I can't say "these questions suck, show me this question I just thought up instead": that'd be silly. So, it's imperative the question list have a high signal-to-noise ratio, and removing the penalty for those users who do take the time to read a question and later find it to be useless so they can down-vote is conducive to that.
-</blockquote>
+
 
 
 

--- a/_posts/2011-07-11-faster-edits-with-inline-editing.markdown
+++ b/_posts/2011-07-11-faster-edits-with-inline-editing.markdown
@@ -19,11 +19,11 @@ Every Stack Exchange question and answer pair is intended to be an [evergreen, e
 
 
 
-<blockquote>
+>
 The editing feature is there so that old question/answer pairs can get better and better. For every person who asks a question and gets an answer on Stack Exchange, hundreds or thousands of people will come read that conversation later. Even if the original asker got a decent answer and moved on, the question lives on and may continue to be useful for decades.
 
+>
 This is fundamentally different from Usenet or any of the web-based forums. It means that Stack Exchange is not just a historical record of questions and answers. It's a lot more than that: it's actually a community-edited wiki of narrow, "long-tail" questions -- questions that aren’t quite important enough to deserve a page on Wikipedia, but which come up over and over again.
-</blockquote>
 
 
 

--- a/_posts/2011-07-14-how-much-should-you-pay-developers.markdown
+++ b/_posts/2011-07-14-how-much-should-you-pay-developers.markdown
@@ -19,18 +19,23 @@ So we sat down and thought out developer compensation from basic principles, and
 
 
 
-<blockquote>The development team at Stack Exchange is an amazing group of programmers who live up to our motto of “smart and get things done” every day.
+>The development team at Stack Exchange is an amazing group of programmers who live up to our motto of “smart and get things done” every day.
 
-We want to offer them compensation that is fair, easily understood, transparent, and competitive. 
+>
+We want to offer them compensation that is fair, easily understood, transparent, and competitive.
 
+>
 _Fair_ means no games. Our compensation is not based on how well you negotiate or how often you ask for raises—it’s based on a repeatable predictable system. There’s no forced ranking, so other people don’t have to do badly for you to do well. We don’t have a range of possible salaries for every level, we have a single salary, so everything about the system is algorithmic.
 
+>
 _Easily understood_ means that any developer can figure out what their salary should be according to this system. They can see what they need to do to move up in their career. And different managers can figure out how to pay their team members and get consistent and fair results.
 
+>
 _Transparent_ reflects Stack Exchange’s core beliefs about running our business in the open, without secrets. It means that if a list of everyone’s salary suddenly appeared on Wikileaks, nobody would be surprised enough to be upset. Transparency is essential to insure fairness.
 
+>
 _Competitive_ means that you’re earning at least as much at Stack Exchange as you would earn elsewhere. It’s critical to being able to attract and retain the kind of developers we want working for us. If our compensation system isn’t competitive, we won’t be able to hire the people we want without giving them an “exceptional” salary, and exceptions defeat fairness.
-</blockquote>
+
 
 
 

--- a/_posts/2011-07-27-does-this-site-have-a-chance-of-succeeding.markdown
+++ b/_posts/2011-07-27-does-this-site-have-a-chance-of-succeeding.markdown
@@ -72,9 +72,10 @@ A steady influx of questions is a natural side effect of a growing, healthy site
 Joel suggested a _healthier_ alternative by rallying users around specific _events_ as a catalyst for asking interesting questions you come across in your day to day work. Any event that gets your community going — a hot new release, an upcoming convention, any news-worthy event — [Here’s how he did it on Ask Different](http://meta.apple.stackexchange.com/questions/589/now-that-lion-is-out-help-promote-ask-different):
 
 
-<blockquote>Now that OS X Lion is shipping, there will be zillions of Mac users upgrading, and they'll have lots of questions. And since all those questions will be new, Ask Different will have as good a shot at having the best answer than any of those, you know, competitive sites. Essentially, this is a great time to recruit new members!
+>Now that OS X Lion is shipping, there will be zillions of Mac users upgrading, and they'll have lots of questions. And since all those questions will be new, Ask Different will have as good a shot at having the best answer than any of those, you know, competitive sites. Essentially, this is a great time to recruit new members!
 
-As you install and learn Lion, whenever you have questions, no matter how silly, _ask them here_. You're not the only one having that question. Millions of other people will, too. Ask them even if you think you're going to be able to find the answer yourself... and if you do find the answer, go ahead and answer it yourself …</blockquote>
+>
+As you install and learn Lion, whenever you have questions, no matter how silly, _ask them here_. You're not the only one having that question. Millions of other people will, too. Ask them even if you think you're going to be able to find the answer yourself... and if you do find the answer, go ahead and answer it yourself …
 
 
 [Read the post](http://meta.apple.stackexchange.com/questions/589/now-that-lion-is-out-help-promote-ask-different) and issue a call for questions around interesting events that will be super-popular in_ your_ community. Those questions will bring in lots of traffic from search engines and will attract some great new users who will add value for years to come.

--- a/_posts/2011-08-10-reputation-not-rep.markdown
+++ b/_posts/2011-08-10-reputation-not-rep.markdown
@@ -16,9 +16,10 @@ I get an email like [Arik](http://blogs.microsoft.co.il/blogs/arik/)'s every day
 
 
 
-<blockquote>The problem I see is that Careers 2.0 give advantage to developers with high Stack Overflow statistics (which I guess was the point, showing that you know stuff).
- 
-Unfortunately, SO succeeded so well, that practically no good question remained unanswered. Thus, gaining a respectful reputation in SO is practically impossible these days. Which gives an unfair advantage to veteran SO users.</blockquote>
+> The problem I see is that Careers 2.0 give advantage to developers with high Stack Overflow statistics (which I guess was the point, showing that you know stuff).
+
+>
+Unfortunately, SO succeeded so well, that practically no good question remained unanswered. Thus, gaining a respectful reputation in SO is practically impossible these days. Which gives an unfair advantage to veteran SO users.
 
 
 

--- a/_posts/2011-08-10-welcome-valued-associate-chris-jaeger.markdown
+++ b/_posts/2011-08-10-welcome-valued-associate-chris-jaeger.markdown
@@ -29,11 +29,13 @@ Chris is a bit private in nature, but that's okay; We hire community managers fo
 ![](/images/wordpress/Chris-Jaeger-duck.jpg)
 
 
-<blockquote>Chris is a gamer by heart and heritage, and thus a lot of her life comes from his love for video games. Learning artistic skills, practicing creative writing, coding small tests, and a fair amount of documentation occupies the majority of her time. The one thing more he cherishes more is her family, and he greatly enjoys that her new job lets him keep their new Southwick home from being a lonely place during the day, even if she can't keep his mother company during the day proper. It may seem like a quiet boring life, but she manages to keep it interesting enough for stories, whether it's setting his hair on fire during Biology class or being hounded by a white wasp for the entire length of a highway drive.
+>Chris is a gamer by heart and heritage, and thus a lot of her life comes from his love for video games. Learning artistic skills, practicing creative writing, coding small tests, and a fair amount of documentation occupies the majority of her time. The one thing more he cherishes more is her family, and he greatly enjoys that her new job lets him keep their new Southwick home from being a lonely place during the day, even if she can't keep his mother company during the day proper. It may seem like a quiet boring life, but she manages to keep it interesting enough for stories, whether it's setting his hair on fire during Biology class or being hounded by a white wasp for the entire length of a highway drive.
 
+>
 Chris first found Stack Overflow in a very traditional success story — When she needed assistance for his SharePoint application on a previous employment. When the site continued to come up on future problems, she eventually gave a shot at answering, an experience that soon cascaded to the birth and guidance of the Gaming Stack Exchange that is her main haunt. He looks forward to working with everyone to help continue to sculpt the growth and communities of all of the Network.
 
-Chris is not fond of posting her picture online (very strongly emphasized by his lack of presence on any social network), but she endeavored nonetheless to procure an image from his past — from graduation, as it were. She hopes it'll be satisfactory. ♪</blockquote>
+>
+Chris is not fond of posting her picture online (very strongly emphasized by his lack of presence on any social network), but she endeavored nonetheless to procure an image from his past — from graduation, as it were. She hopes it'll be satisfactory. ♪
 
 
 Welcome to the team, Chris! ♪

--- a/_posts/2011-08-16-gorilla-vs-shark.markdown
+++ b/_posts/2011-08-16-gorilla-vs-shark.markdown
@@ -22,13 +22,15 @@ OK, maybe you're thinking that's a ridiculous question. Perhaps it is. But vario
 
 
 
-<blockquote>
+>
 Okay, so I'm finally making the jump into scripting languages and I have decided to focus on either Python or Perl. The problem is: I don't know which to cut my teeth on.
 
+>
 Most of my programming experience is in C, Java, and C++. There's no specific task I would be learning Python/Perl for, other that possibly applying it to my dev work to make life easier in general.
 
+>
 What do you think? Which do you use? Is one more industry relevant than another?
-</blockquote>
+
 
 
 
@@ -38,11 +40,12 @@ This question, or anything like it, would be _instantly_ closed as "not construc
 
 
 
-<blockquote>
+>
 **not constructive**
 
+>
 This question is not a good fit to our Q&A; format. We expect answers to generally involve facts, references, or specific expertise; this question will likely solicit opinion, debate, arguments, polling, or extended discussion.
-</blockquote>
+
 
 
 

--- a/_posts/2011-09-20-creative-commons-data-dump-sep-11.markdown
+++ b/_posts/2011-09-20-creative-commons-data-dump-sep-11.markdown
@@ -15,7 +15,7 @@ tags:
 ---
 
 <blockquote>
-While we will always continue to produce Stack Exchange creative commons data dumps, we are moving to a quarterly schedule for all future dumps. We won't be blogging each and every one, as it gets a bit monotonous. Please **[subscribe to our Clear Bits creator feed](http://www.clearbits.net/creators/146-stack-exchange-data-dump)** to be automatically notified when new Stack Exchange creative commons data dumps become available!
+While we will always continue to produce Stack Exchange creative commons data dumps, we are moving to a quarterly schedule for all future dumps. We won't be blogging each and every one, as it gets a bit monotonous. Please <strong><a href="http://www.clearbits.net/creators/146-stack-exchange-data-dump">subscribe to our Clear Bits creator feed</a></strong> to be automatically notified when new Stack Exchange creative commons data dumps become available!
 </blockquote>
 
 

--- a/_posts/2011-09-23-bounty-reasons-and-post-notices.markdown
+++ b/_posts/2011-09-23-bounty-reasons-and-post-notices.markdown
@@ -24,31 +24,30 @@ Upon further reflection, we realized that it can be difficult to tell exactly wh
 
 
 
-<blockquote>
-**Authoritative reference needed**  
+> **Authoritative reference needed**
 
-Looking for an answer drawing from credible and/or official sources.
+> Looking for an answer drawing from credible and/or official sources.
 
-**Canonical answer required**  
+> **Canonical answer required**
 
-The question is widely applicable to a large audience. A detailed canonical answer is required to address all the concerns.
+> The question is widely applicable to a large audience. A detailed canonical answer is required to address all the concerns.
 
-**Current answers are outdated**  
+> **Current answers are outdated**
 
-The current answer(s) are out-of-date and require revision given recent changes.
+> The current answer(s) are out-of-date and require revision given recent changes.
 
-**Draw attention**  
+> **Draw attention**
 
-This question has not received enough attention.
+> This question has not received enough attention.
 
-**Improve details**  
+> **Improve details**
 
-The current answers do not contain enough detail.
+> The current answers do not contain enough detail.
 
-**Reward existing answer**  
+> **Reward existing answer**
 
-One or more of the answers is exemplary and worthy of an additional bounty.
-</blockquote>
+> One or more of the answers is exemplary and worthy of an additional bounty.
+
 
 
 

--- a/_posts/2011-11-03-the-best-of-blog-overflow-october-2011.markdown
+++ b/_posts/2011-11-03-the-best-of-blog-overflow-october-2011.markdown
@@ -21,7 +21,7 @@ We've noticed that our site-specific blogs have some amazing content that just i
 ****Fitness has a post that struck a chord with a lot of us: [Finding a Fitness Niche](http://fitness.blogoverflow.com/2011/10/finding-a-fitness-niche/). The author shares a story that felt a little too close for comfort; despite having done a lot of different athletic things in his youth, he had trouble finding an activity that both piqued and held his interest. It's something we think many people, techies and geeks and civilians alike, have trouble with.
 
 
-<blockquote>_I’m a nerd. I’ve always been one since I was a kid. I never grasped the rules of sports that other kids just seemed to innately understand. I lacked coordination, strength, and speed which resulted in me being picked almost always last for any kind of team sport. That was a regular experience for me since early elementary school all throughout the end of high school._</blockquote>
+<blockquote>I’m a nerd. I’ve always been one since I was a kid. I never grasped the rules of sports that other kids just seemed to innately understand. I lacked coordination, strength, and speed which resulted in me being picked almost always last for any kind of team sport. That was a regular experience for me since early elementary school all throughout the end of high school.</blockquote>
 
 
 [**DIY**](http://diy.blogoverflow.com/)
@@ -29,7 +29,7 @@ We've noticed that our site-specific blogs have some amazing content that just i
 We here at Stack Exchange have something of a soft spot for DIY Home Improvement. Not only have we had one of their top users [guest star on our podcast](http://blog.stackoverflow.com/2011/06/se-podcast-10/), but a [number](http://diy.stackexchange.com/questions/5653/what-is-the-right-way-to-connect-7-conductors-in-an-electrical-box) [of us](http://diy.stackexchange.com/questions/5289/does-the-specific-gravity-of-a-lead-acid-battery-indicate-degradation/5830#5830) [have asked](http://diy.stackexchange.com/questions/1733/doors-are-sticky-and-noisy-when-opened) questions on there. So when the site users finally banded together to get a blog up, well, only good could come of it. Our pick for October is this entry: [Romancing the Floor: Saving and Restoring Old Hardwood](http://diy.blogoverflow.com/2011/10/romancing-the-floor-saving-and-restoring-old-hardwood/). This entry is fantastic; lots of photographs, step-by-step chatter about the process, and a lot of honesty about how he went about bringing the floor back from the edge of terrible. Plus, the author has a wry sense of humor -- always a bonus.
 
 
-<blockquote>_Now we were ready for the next step – the power sander! Now this is a step that, quite honestly, should not be undertaken by the faint at heart, or the inexperienced, when you really care about how the floor ends up looking. In our case, the floor was original 1940 hardwood and we figured a little damage was “character” (hey, at 67 years old, see if YOU look this good!). It’s a good thing we didn’t mind too much because learning how to handle a drum sander takes a bit of getting used to._</blockquote>
+<blockquote>Now we were ready for the next step – the power sander! Now this is a step that, quite honestly, should not be undertaken by the faint at heart, or the inexperienced, when you really care about how the floor ends up looking. In our case, the floor was original 1940 hardwood and we figured a little damage was “character” (hey, at 67 years old, see if YOU look this good!). It’s a good thing we didn’t mind too much because learning how to handle a drum sander takes a bit of getting used to.</blockquote>
 
 
 In a similar vein (and a close second) was [this entry](http://diy.blogoverflow.com/2011/10/how-many-ways-can-a-diyer-screw-up-a-drywall-patch/) about patching drywall and popcorn ceilings.
@@ -39,9 +39,9 @@ In a similar vein (and a close second) was [this entry](http://diy.blogoverflow.
 The Sci-Fi and Fantasy blog did a great entry about [the order in which to watch the _Star Wars_ movies](http://scifi.blogoverflow.com/2011/10/scifi-stackexchange-in-practical-use-in-what-order-should-the-star-wars-movies-be-watched/). This is one of those questions that causes a great deal of angst amongst _Star Wars_ fans.
 
 
-<blockquote>_This [question] got me thinking about more than just how I voted on that one question, but how I vote on a lot of questions. I fully support ever answer I upvote, but in all honesty, most of the answers that I have given the “big up arrow” to were ones I just believed were right._
+> This [question] got me thinking about more than just how I voted on that one question, but how I vote on a lot of questions. I fully support ever answer I upvote, but in all honesty, most of the answers that I have given the “big up arrow” to were ones I just believed were right.
 
-_But I wanted to change that. I wanted to actually use the information given to me on this wonderful site and put it to practical use._</blockquote>
+> But I wanted to change that. I wanted to actually use the information given to me on this wonderful site and put it to practical use.
 
 
 [**IT Security**](http://security.blogoverflow.com/)
@@ -49,7 +49,7 @@ _But I wanted to change that. I wanted to actually use the information given to 
 Over in Security, we have an entry that [ties in very nicely](http://blog.stackoverflow.com/2011/11/se-podcast-25-mark-russinovich/) with our most recent podcast: [Risk Assessments: Knowing What to Protect](http://security.blogoverflow.com/2011/10/risk-assessments-knowing-what-to-protect/). This entry sums up the crux of business risk, and why security is not only relevant to everyone, but also a constant struggle, as epitomized by the recent Sony hack.
 
 
-<blockquote>_It may seem a surreal comparison, but data exposure can have an impact as substantial as losing a primary building. A bank without customer records is dead regardless of the cash on hand. A bank with all its customer records made public is at risk of the same fate. Illegitimate transactions, damage to reputation, liability for customer losses related to disclosure and regulatory reaction may all work together to end an institution._</blockquote>
+<blockquote>It may seem a surreal comparison, but data exposure can have an impact as substantial as losing a primary building. A bank without customer records is dead regardless of the cash on hand. A bank with all its customer records made public is at risk of the same fate. Illegitimate transactions, damage to reputation, liability for customer losses related to disclosure and regulatory reaction may all work together to end an institution.</blockquote>
 
 
 Honorable mention goes to their [post about password strings](http://security.blogoverflow.com/2011/10/how-long-is-a-password-string/), based on the recent [XKCD comic](http://www.xkcd.com/936/).

--- a/_posts/2011-12-02-the-best-of-blog-overflow-november-2011.markdown
+++ b/_posts/2011-12-02-the-best-of-blog-overflow-november-2011.markdown
@@ -46,26 +46,27 @@ This past month, the TeX (pronounced like "tech" for those unaware) blog [interv
 
 We'll finish on something a bit more lighthearted:
 
-_Our English Language blog's so cool!
-I'll read it and learn a new rule
-[Or other awesome thing](http://english.blogoverflow.com/2011/11/the-basics-of-limerick-composition/)
-That I can then bring
+_Our English Language blog's so cool!<br/>
+I'll read it and learn a new rule<br/>
+[Or other awesome thing](http://english.blogoverflow.com/2011/11/the-basics-of-limerick-composition/)<br/>
+That I can then bring<br/>
 To the "Best of Site Blogs" pool!_
 
 Or, if you prefer:
 
-_We have here an awesome blog post
-That could teach one to be the toast
-Of any cool parties
-And seem a real smartie,
+_We have here an awesome blog post<br/>
+That could teach one to be the toast<br/>
+Of any cool parties<br/>
+And seem a real smartie,<br/>
 While staying refined, unlike most!_
 
 
-<blockquote>Two things that can indicate a good grasp of a language, at least in the case of English, are the abilities to pun and to rhyme.
+> Two things that can indicate a good grasp of a language, at least in the case of English, are the abilities to pun and to rhyme.
 
+>
 Punning is probably more difficult than rhyming, since it requires not only a good grasp of pronunciation and a swift vocabulary, but also knowledge of the meaning of a great many words and idioms.
 
-One of my favourite British pastimes that involves a lot of rhyming and occasional punning, is that of writing limericks.</blockquote>
+> One of my favourite British pastimes that involves a lot of rhyming and occasional punning, is that of writing limericks.
 
 
 There you have it -- a nice assortment of awesome entries from BlogOverflow. Don't get me wrong; these aren't the _only_ entries posted this month. [Gaming](http://blog.gaming.stackexchange.com/), for example, had a number of really interesting entries this past month, covering everything from [videos about game launches](http://blog.gaming.stackexchange.com/2011/11/its-skyrim-time/) to [ruining a good game with background "music"](http://blog.gaming.stackexchange.com/2011/11/scoregasm/).

--- a/_posts/2011-12-08-dont-be-afraid-to-use-the-science.markdown
+++ b/_posts/2011-12-08-dont-be-afraid-to-use-the-science.markdown
@@ -126,7 +126,7 @@ We do what we can to help new users understand how to base their answer on somet
 
 
 
-<blockquote>
+>
 Thanks for contributing an answer to {sitename}!
 
 > 
@@ -140,7 +140,6 @@ Provide details and share your research. Avoid statements based solely on opinio
 > 
 > 
 To learn more, see our [tips on writing great answers](http://superuser.com/questions/how-to-answer).
-</blockquote>
 
 
 

--- a/_posts/2011-12-12-protect-intellectual-property-but-not-like-this.markdown
+++ b/_posts/2011-12-12-protect-intellectual-property-but-not-like-this.markdown
@@ -16,7 +16,7 @@ tags:
 Last week, there was a lot of [hubbub on Meta Stack Overflow](http://meta.stackoverflow.com/questions/tagged/sopa) about a system message that ran on Stack Overflow. The system message read:
 
 
-<blockquote>SOPA is a dangerous law. It breaks the Internet and threatens sites like Stack Overflow. [Protect the Internet](http://americancensorship.org/)!</blockquote>
+<blockquote>SOPA is a dangerous law. It breaks the Internet and threatens sites like Stack Overflow. <a href="http://americancensorship.org/">Protect the Internet</a>!</blockquote>
 
 
 For the intents and purposes of this post, let’s bypass the controversy surrounding whether or not this is an [appropriate use of system messages](http://meta.stackoverflow.com/questions/114020/please-do-not-use-stack-overflow-to-promote-social-causes) and simply focus on the important parts: why [SOPA](http://en.wikipedia.org/wiki/Stop_Online_Piracy_Act) and [PROTECT IP](http://en.wikipedia.org/wiki/PROTECT_IP_Act) are bad news for Stack Exchange, the United States, the Internet, and the world.

--- a/_posts/2011-12-20-gaming-holiday-promotion-hat-dash.markdown
+++ b/_posts/2011-12-20-gaming-holiday-promotion-hat-dash.markdown
@@ -23,10 +23,7 @@ Between December 16 and January 6, users can unlock hats for their gravatars on 
 
 <blockquote>
 
-> 
-> ## [Holiday 2011 Hat Dash: The Hattening](http://blog.gaming.stackexchange.com/2011/12/holiday-2011-hat-dash-the-hattening/)
-> 
-> 
+<h2><a href="http://blog.gaming.stackexchange.com/2011/12/holiday-2011-hat-dash-the-hattening/">Holiday 2011 Hat Dash: The Hattening</a></h2>
 </blockquote>
 
 

--- a/_posts/2011-12-23-stack-exchange-gives-back-2011.markdown
+++ b/_posts/2011-12-23-stack-exchange-gives-back-2011.markdown
@@ -16,10 +16,12 @@ tags:
 I'm sitting up late this evening trying to think of an inspirational way to end this year with some grandiloquent statement about our growth and the great job everyone has done this year. I don't know; maybe it's the glow of the Christmas tree behind me, or the eggnog recipe I've been experimenting with… but, really, anything I can say here can only lessen the outpouring that comes following this…
 
 
-<blockquote>Greetings to the Stack Exchange Moderators,
+> Greetings to the Stack Exchange Moderators,
 
+>
 In a yearly tradition at Stack Exchange, we set aside this time of year to [make sure we are "giving back"](../2010/12/stack-overflow-gives-back-2010/) to effect positive change in the world. As a moderator, you play such a crucial role in our success, and we would like to include you in that effort.
 
+>
 As a small gesture of thanks, we would like to make a **$100 donation to charity on behalf of each community moderator**. The link below leads to a brief form where you can select which charity you wish to receive the donation.
 
 > 
@@ -28,9 +30,10 @@ As a small gesture of thanks, we would like to make a **$100 donation to charity
 > 
 It is my hope that, together, we can continue this tradition year after year — and with 220+ moderators, that donation will only continue to increase.
 
+>
 So, thanks to everyone who participated in Stack Exchange. Thank you for generously contributing your time, your passion, and your leadership, all of which made these donations possible.
 
-- The Stack Exchange Team</blockquote>
+> - The Stack Exchange Team
 
 
 We started with [12 moderators](http://blog.stackoverflow.com/2009/12/stack-overflow-gives-back/), [then 130](http://blog.stackoverflow.com/2010/12/stack-overflow-gives-back-2010/) — and now **[on behalf of the 228 moderators of Stack Exchange](http://stackexchange.com/about/moderators?by=users)**, we made a donation to the following charities this holiday season:

--- a/_posts/2012-01-05-hot-topics-a-contest-formula-that-works.markdown
+++ b/_posts/2012-01-05-hot-topics-a-contest-formula-that-works.markdown
@@ -18,9 +18,10 @@ tags:
 CHAOS has been searching for the perfect way to promote activity on our sites for a while now. After all, before you can try to recruit new users, you need to engage your existing community. Since we’re a network of Q&A websites, a natural place to start is having question-asking contests. Some of our contests have been more successful than [others](http://meta.math.stackexchange.com/questions/3212/battle-of-the-sites-cancelled), but it seems like we’ve finally found one that works:
 
 
-<blockquote>**What**: Hot Topic of the Week
+> **What**: Hot Topic of the Week
 
-**How it works**: Pick a topic of the week, and enter everyone who asks a question related to that topic into a random drawing to win a prize. The number of entries a person gets is equal to the number of questions they ask about the topic of the week.</blockquote>
+>
+**How it works**: Pick a topic of the week, and enter everyone who asks a question related to that topic into a random drawing to win a prize. The number of entries a person gets is equal to the number of questions they ask about the topic of the week.
 
 
 This is similar to the weekly topic challenge being held on [Jewish Life & Learning](http://meta.judaism.stackexchange.com/questions/441/weekly-topic-challenge-call-for-proposals), but adapted to a contest model. It’s pretty simple, but surprisingly effective, and there are a few key reasons why it works.

--- a/_posts/2012-01-31-the-trouble-with-popularity.markdown
+++ b/_posts/2012-01-31-the-trouble-with-popularity.markdown
@@ -53,19 +53,22 @@ Ironically, the Reddit community itself now recognizes that [moderation is funda
 ):
 
 
-<blockquote>One thing thing that does concern me, however, is that [as this subreddit gets more popular] the amount of image macros, memes, rage comics and generally low-quality content hitting the front page has grown to annoying proportions.
+> One thing thing that does concern me, however, is that [as this subreddit gets more popular] the amount of image macros, memes, rage comics and generally low-quality content hitting the front page has grown to annoying proportions.
 
+>
 **The problem with image macros and rage comics (besides generally lacking wit or anything genuinely insightful) is that they're quick and easy to digest, and thus tend to get upvoted faster than self posts and actual discussions which take thought and time before an appropriate response can meted out.** If you're not careful you end up with something akin to /r/gaming, which is now a burbling, deformed wreck of its former self, with anything remotely resembling intelligent discussion being buried under a sea of vacuous meme-repetition.
 
-In my view what this subreddit needs is a touch more moderation to ensure that we don't end up with a front page full of imgur/memegenerator links, and that people who want to use this subreddit as a medium to discuss the [topic] can do so without having to sift through the crap with a shovel.</blockquote>
+>
+In my view what this subreddit needs is a touch more moderation to ensure that we don't end up with a front page full of imgur/memegenerator links, and that people who want to use this subreddit as a medium to discuss the [topic] can do so without having to sift through the crap with a shovel.
 
 
 This is as clear a call for active moderation as I've ever seen. And the moderators, to their credit, [took charge and instituted changes](http://www.reddit.com/r/battlefield3/comments/o7y4x/new_community_rules_please_read/) to help guide their community away from the fatty junk food content:
 
 
-<blockquote>We’ve heard your concerns over the direction the community is heading. We were hoping we could ride it out and things would balance themselves, but it just isn't working, and things need to change. **It’s plain to see that meme-based content attracts many upvotes, and we all love a good laugh, but it is not what we want this community to be.** But this isn't just about memes, it's about the general tone of the community. We’re making changes to our rules for posting, commenting, and voting here -- necessary changes to make [this] the community we first envisioned.
+> We’ve heard your concerns over the direction the community is heading. We were hoping we could ride it out and things would balance themselves, but it just isn't working, and things need to change. **It’s plain to see that meme-based content attracts many upvotes, and we all love a good laugh, but it is not what we want this community to be.** But this isn't just about memes, it's about the general tone of the community. We’re making changes to our rules for posting, commenting, and voting here -- necessary changes to make [this] the community we first envisioned.
 
-This community is for sharing thought-provoking stories, high-level tactics discussions, videos/images of the awesomeness of [topic], suggestions or discussions on mechanics, and it can all be done without resorting to memes or complaining. Reddit never ceases to amaze, I expect to be surprised! If you have any questions, message the mods! We hope you agree and understand these changes.</blockquote>
+>
+This community is for sharing thought-provoking stories, high-level tactics discussions, videos/images of the awesomeness of [topic], suggestions or discussions on mechanics, and it can all be done without resorting to memes or complaining. Reddit never ceases to amaze, I expect to be surprised! If you have any questions, message the mods! We hope you agree and understand these changes.
 
 
 We know that closing the cookie jar is painful. We feel your pain. Nobody likes having their fun taken away. But it's too addictive and too easy, and in the absence of any moderation, the community would do nothing but add and upvote the easy, fun stuff.
@@ -73,7 +76,7 @@ We know that closing the cookie jar is painful. We feel your pain. Nobody likes 
 This is why community moderators have real power; they _need_ that power to intervene, educate, and refocus the community's exuberance on more substantive content. People will fight you almost literally to the death over their right to be entertained, and to entertain others:
 
 
-<blockquote>Why can't you just not look at these fun posts? Why do they have to be _deleted?_ You guys suck!</blockquote>
+<blockquote>Why can't you just not look at these fun posts? Why do they have to be <em>deleted?</em> You guys suck!</blockquote>
 
 
 The same reason the moderators and community on that subreddit didn't decide to "not look" at the fun posts, really:

--- a/_posts/2012-02-24-stack-exchanges-greatest-hits.markdown
+++ b/_posts/2012-02-24-stack-exchanges-greatest-hits.markdown
@@ -29,14 +29,13 @@ How do we, as community members, tell which questions are getting the most airpl
 
 
 
-<blockquote>
-[stackoverflow.com/questions/greatest-hits](http://stackoverflow.com/questions/greatest-hits)
-[superuser.com/questions/greatest-hits](http://superuser.com/questions/greatest-hits)
-[serverfault.com/questions/greatest-hits](http://serverfault.com/questions/greatest-hits)
-[gaming.stackexchange.com/questions/greatest-hits](http://gaming.stackexchange.com/questions/greatest-hits)
-[askubuntu.com/questions/greatest-hits](http://askubuntu.com/questions/greatest-hits)
+>
+[stackoverflow.com/questions/greatest-hits](http://stackoverflow.com/questions/greatest-hits)<br/>
+[superuser.com/questions/greatest-hits](http://superuser.com/questions/greatest-hits)<br/>
+[serverfault.com/questions/greatest-hits](http://serverfault.com/questions/greatest-hits)<br/>
+[gaming.stackexchange.com/questions/greatest-hits](http://gaming.stackexchange.com/questions/greatest-hits)<br/>
+[askubuntu.com/questions/greatest-hits](http://askubuntu.com/questions/greatest-hits)<br/>
 [apple.stackexchange.com/questions/greatest-hits](http://apple.stackexchange.com/questions/greatest-hits)
-</blockquote>
 
 
 

--- a/_posts/2012-02-29-lets-play-the-guessing-game.markdown
+++ b/_posts/2012-02-29-lets-play-the-guessing-game.markdown
@@ -23,15 +23,18 @@ All these questions are effectively **guessing games**.
 
 
 
-<blockquote>
+>
   I remember myself playing this a bit childish, but in some ways awesome game, where you control a tank, and can pick up and stack turrets (and maybe something else) from enemy tanks you kill. Maybe they also had different platforms (and if it's one with wheels then technically it's not a tank, but hey). It was around 2000 (or maybe even earlier) and the game had 3D graphics.
   
+>
   Trying to remember a book I read in the 80s, reptiles are dominant, have language, have human slaves. Northern human tribes attack the reptile settlements. The reptiles have gourds of partially digested food...they use some type of slug creature to clean hair and fur off mammals.
   
+>
   Please help me finding the single word for representing a person who guides at right time (at the time of need).
   
+>
   I am looking for a children's book that features a mouse. He lives in a red ticket booth and sleeps in a drawer and rides a motorcycle. It is either a chapter book or a collection of short stories about this mouse.
-</blockquote>
+
 
 
 

--- a/_posts/2012-03-02-enterprise-vs-consumer-development.markdown
+++ b/_posts/2012-03-02-enterprise-vs-consumer-development.markdown
@@ -21,13 +21,14 @@ One of my first projects after joining Stack Exchange was giving the job applica
 Probably the most eloquent explanation of the differences between Consumer and Enterprise product development comes from one of my most favourite people in tech, the late Steve Jobs:
 
 
-<blockquote>
+>
 
 > 
 > 
 We're about making better products, and what I love about the consumer market that I always hated about the enterprise market, is that we come up with a product, we try to tell everybody about it, and every person votes for themselves. They go, "Yes" or "No"!
 
-And if enough of them say "yes" we get to come to work tomorrow! ...</blockquote>
+>
+And if enough of them say "yes" we get to come to work tomorrow! ...
 
 
 
@@ -80,11 +81,7 @@ In the blockbuster movie hit "Jaws", Stephen Spielberg attributed much of the su
 
 
 <blockquote>
-
-> 
-> "The shark not working was a godsend. It made me become more like Alfred Hitchcock than like Ray Harryhausen."
-> 
-> 
+"The shark not working was a godsend. It made me become more like Alfred Hitchcock than like Ray Harryhausen."
 </blockquote>
 
 
@@ -94,11 +91,7 @@ The first was a legal issue only discovered after I implementing a Google Docs v
 
 
 <blockquote>
-
-> 
-> "By submitting, posting or displaying the content you give Google a perpetual, irrevocable, worldwide, royalty-free, and non-exclusive license to reproduce, adapt, modify, translate, publish, publicly perform, publicly display and distribute any Content which you submit, post or display on or through, the Services."
-> 
-> 
+"By submitting, posting or displaying the content you give Google a perpetual, irrevocable, worldwide, royalty-free, and non-exclusive license to reproduce, adapt, modify, translate, publish, publicly perform, publicly display and distribute any Content which you submit, post or display on or through, the Services."
 </blockquote>
 
 

--- a/_posts/2012-03-06-reputation-and-historical-archives.markdown
+++ b/_posts/2012-03-06-reputation-and-historical-archives.markdown
@@ -17,7 +17,7 @@ tags:
 If you've been around Meta Stack Overflow the past few days, you've seen a fair bit of conversation sparked by [the recent changes to how reputation is calculated](http://meta.stackoverflow.com/questions/123319/recent-reputation-history-changes):
 
 
-<blockquote>To be clear: **reputation values are not changing, every action in the system is still worth the same amount**. Here’s what _will_ be different:
+>To be clear: **reputation values are not changing, every action in the system is still worth the same amount**. Here’s what _will_ be different:
 
 > 
 > 
@@ -40,7 +40,6 @@ If you've been around Meta Stack Overflow the past few days, you've seen a fair 
 >   * The reputation history in your profile will be more detailed and accurate (e.g. when a post is deleted, you'll see that in the reputation tab of your profile)
 > 
 
-</blockquote>
 
 
 This may sound pretty boring - and it is - but it's a big deal for some of our most avid users, for whom that number at the top of the screen is an at-a-glance indicator of how their contributions are faring on the site. Up until now, the reputation visible next to your name on your profile was a rough aproximation of your _real_ reputation - [only a recalculation](http://blog.stackoverflow.com/2010/03/the-great-reputation-recalc-begins/) would resolve all the discrepancies that crept in over time.

--- a/_posts/2012-03-22-respect-the-community-your-own-and-others.markdown
+++ b/_posts/2012-03-22-respect-the-community-your-own-and-others.markdown
@@ -18,7 +18,7 @@ tags:
 In [“Why Can’t You Have Just One Site?”](http://blog.stackoverflow.com/2009/07/why-cant-you-have-just-one-site/) Jeff wrote about the rationale for creating three sites instead of one, and the process for determining where a question belongs:
 
 
-<blockquote>Is it really so hard to figure out which community you belong to, and thus, where your question belongs? Ask yourself this:
+>Is it really so hard to figure out which community you belong to, and thus, where your question belongs? Ask yourself this:
 
 > 
 > 
@@ -32,7 +32,8 @@ In [“Why Can’t You Have Just One Site?”](http://blog.stackoverflow.com/200
 >   * what are you trying to accomplish?
 > 
 
-You can use the same mountain to go downhill really fast on snow — but it’s plainly evident to the participant which culture they consider themselves a part of, “skiers” or “snowboarders”.</blockquote>
+>
+You can use the same mountain to go downhill really fast on snow — but it’s plainly evident to the participant which culture they consider themselves a part of, “skiers” or “snowboarders”.
 
 
 ![](http://i.stack.imgur.com/5yNpA.png)We’ve since grown from a Trilogy to a network of 84 sites. Our audience is large enough to allow a considerable amount of specialization: [Apple](http://askdifferent.com/), [Ubuntu](http://askubuntu.com/), [WordPress ](http://wordpress.stackexchange.com/)and [Database Administrators](http://dba.stackexchange.com/) all cover topics that previously belonged on [Super User](http://superuser.com/), [Stack Overflow](http://stackoverflow.com/) or [Server Fault](http://serverfault.com/). But the same philosophy still applies: before you can decide where to ask, you need to know who to ask. And _who_ you ask will depend (at least in part) on who _you_ are...

--- a/_posts/2012-04-20-more-notes-on-contest-format.markdown
+++ b/_posts/2012-04-20-more-notes-on-contest-format.markdown
@@ -20,11 +20,7 @@ A few months ago, I[ outlined a contest formula](http://blog.stackoverflow.com/2
 
 
 <blockquote>
-
-> 
-> Pick a topic of the week, and enter everyone who asks a question related to that topic into a random drawing to win a prize. The number of entries a person gets is equal to the number of questions they ask about the topic of the week.
-> 
-> 
+Pick a topic of the week, and enter everyone who asks a question related to that topic into a random drawing to win a prize. The number of entries a person gets is equal to the number of questions they ask about the topic of the week.
 </blockquote>
 
 
@@ -95,11 +91,7 @@ To rectify the shortcomings of Hot Topics, we’ve come up with a new kind of pr
 
 
 <blockquote>
-
-> 
-> The Mission promotion is pretty simple: design a series of levels, each one more difficult than the last, and give prizes to everyone who completes them.
-> 
-> 
+The Mission promotion is pretty simple: design a series of levels, each one more difficult than the last, and give prizes to everyone who completes them.
 </blockquote>
 
 

--- a/_posts/2012-04-25-when-a-site-grows-quiet.markdown
+++ b/_posts/2012-04-25-when-a-site-grows-quiet.markdown
@@ -19,13 +19,12 @@ tags:
 In the lifecycle of a Stack Exchange site, we've long held the philosophy that "it takes as long as it takes" to build a sustainable community:
 
 
-<blockquote>
 
 > 
 > ## [How long can a site stay in beta?](http://blog.stackoverflow.com/2010/10/when-will-my-site-graduate/)
 > 
 > 
-The simple answer is, _it takes as long as it takes_. We’ll wait. If a site needs more activity, go out and [evangelize it](http://blog.stackoverflow.com/2010/08/a-recipe-to-promote-your-site/). As long as your site shows **steady progress** and continues to make the Internet a better place to get expert answers to your questions, it will march on.</blockquote>
+The simple answer is, _it takes as long as it takes_. We’ll wait. If a site needs more activity, go out and [evangelize it](http://blog.stackoverflow.com/2010/08/a-recipe-to-promote-your-site/). As long as your site shows **steady progress** and continues to make the Internet a better place to get expert answers to your questions, it will march on.
 
 
 But when a site struggles to maintain any semblance of _steady progress_ — when it's struggling to garner an audience, a healthy core of experts, and a steady stream of questions — it becomes increasingly unlikely that the site will find a core audience to sustain it.

--- a/_posts/2012-06-04-2012-stack-overflow-community-moderator-election-begins.markdown
+++ b/_posts/2012-06-04-2012-stack-overflow-community-moderator-election-begins.markdown
@@ -20,7 +20,7 @@ Hard to believe it's been only six months since the last moderator election on S
 Remember [A Theory of Moderation](http://blog.stackoverflow.com/2009/05/a-theory-of-moderation/)? It talks about how moderators are the "human exception handlers" on Stack Overflow, elected to deal with those rare situations the normal community moderation can't handle. It also notes:
 
 
-<blockquote>The most common moderator task is to follow up on [flagged posts](http://blog.stackoverflow.com/2011/01/improved-flagging/). Every post contains a small **flag link**, which anyone with 15 reputation can use.</blockquote>
+<blockquote>The most common moderator task is to follow up on <a href="http://blog.stackoverflow.com/2011/01/improved-flagging/">flagged posts</a>. Every post contains a small <strong>flag link</strong>, which anyone with 15 reputation can use.</blockquote>
 
 
 Over 200K users with at least 15 reputation have accessed Stack Overflow in the past three months. That's a lot of folks able to [raise a red flag](http://blog.stackoverflow.com/2009/04/raising-a-red-flag/) - and a lot of them _do_.

--- a/_posts/2012-07-31-the-hunting-of-the-snark.markdown
+++ b/_posts/2012-07-31-the-hunting-of-the-snark.markdown
@@ -23,7 +23,7 @@ There are different ways of massaging the data, but I do want to give you a flav
 
 
 
-<blockquote>
+>
 
 > 
 > 
@@ -130,7 +130,6 @@ There are different ways of massaging the data, but I do want to give you a flav
 >   * @M.H: Don't blame the language because you don't know how to use it. Don't blame the gun w…
 > 
 
-</blockquote>
 
 
 
@@ -150,7 +149,7 @@ The "friendliness" situation is much better, mainly because our reviewers tend t
 
 
 
-<blockquote>
+>
 
 > 
 > 
@@ -227,7 +226,6 @@ The "friendliness" situation is much better, mainly because our reviewers tend t
 >   * @meagar wow that looks awesome! I'm only about a several hour drive from there, I'll see if I can make it. Juggling for the win!!! :)
 > 
 
-</blockquote>
 
 
 

--- a/_posts/2012-08-08-stack-exchange-is-not-a-forum-the-role-of-niceness-on-a-qa-site.markdown
+++ b/_posts/2012-08-08-stack-exchange-is-not-a-forum-the-role-of-niceness-on-a-qa-site.markdown
@@ -50,8 +50,10 @@ As a traditional forum evolves over time, insular rudeness becomes the weapon of
 Everyone loves to quote from [the FAQ's etiquette section](http://stackoverflow.com/faq#etiquette), particularly the first "be nice" bit. But it's the last section that has all the action items:
 
 
-<blockquote>**Be honest.**
-Above all, be honest. If you see misinformation, vote it down. Add comments indicating what, specifically, is wrong. Provide better answers of your own. Best of all — edit and improve the existing questions and answers!</blockquote>
+>**Be honest.**
+
+>
+Above all, be honest. If you see misinformation, vote it down. Add comments indicating what, specifically, is wrong. Provide better answers of your own. Best of all — edit and improve the existing questions and answers!
 
 
 Tired of seeing crappy questions? Close them. Irritated by lousy answers? Down-vote them. Depressed by the meaningless junk that some people post whenever they see an empty text field? Delete it! Embarrassed by poor grammar or formatting? Edit it! **See someone being rude? Flag it!** All of these tools exist, and [we're working hard on making them better and more effective](http://meta.stackoverflow.com/questions/139536/new-feature-community-review-tasks-now-in-beta).

--- a/_posts/2012-10-26-super-user-win8-challenge.markdown
+++ b/_posts/2012-10-26-super-user-win8-challenge.markdown
@@ -19,7 +19,7 @@ In recognition of this, [Super User is running its own little promotion](http://
 
 
 
-<blockquote>[We’re having a party](http://win8challenge.com/) and you’re invited. Ask and answer questions to complete the challenge levels, and complete different tasks like editing, voting, and blogging to win the eight tile challenges. Each level you beat and each tile you finish enters you for sweet prizes, including the grand prize of a Microsoft Surface RT!</blockquote>
+<blockquote><a href="http://win8challenge.com/">We’re having a party</a> and you’re invited. Ask and answer questions to complete the challenge levels, and complete different tasks like editing, voting, and blogging to win the eight tile challenges. Each level you beat and each tile you finish enters you for sweet prizes, including the grand prize of a Microsoft Surface RT!</blockquote>
 
 
 

--- a/_posts/2013-03-08-2013-so-moderator-election.markdown
+++ b/_posts/2013-03-08-2013-so-moderator-election.markdown
@@ -34,7 +34,7 @@ But of course, we’d be running an election soon anyway; as amazing as [the cur
 Jeff laid out the basic philosophy in [A Theory of Moderation](http://blog.stackoverflow.com/2009/05/a-theory-of-moderation/):
 
 
-<blockquote>**Moderators are human exception handlers**, there to deal with those (hopefully rare) exceptional conditions that should not _normally_ happen, but when they do, they can bring your entire community to a screaming halt — _if_ you don’t have human exception handling in place.</blockquote>
+<blockquote><strong>Moderators are human exception handlers</strong>, there to deal with those (hopefully rare) exceptional conditions that should not <em>normally</em> happen, but when they do, they can bring your entire community to a screaming halt — <em>if</em> you don’t have human exception handling in place.</blockquote>
 
 
 As the previous graph indicates, _flags_ - the primary embodiment of those exceptions - are a fairly frequent occurrence on Stack Overflow, purely because of its size. That said, a lot of flags aren't identifying things that are particularly _exceptional_: in particular, posts that need to be closed (duplicates, off-topic questions, etc) or are of extremely poor quality aren't all that uncommon on a site that gets over 7000 new questions and 11K answers each day. While moderators are well-equipped to handle these _quickly_, they don't actually _require_ moderators when a sufficient number of experienced users are willing and able to help.
@@ -50,7 +50,7 @@ As the previous graph indicates, _flags_ - the primary embodiment of those excep
 As Jeff wrote:
 
 
-<blockquote>We designed the [Stack Exchange network](http://stackexchange.com/sites) engine to be mostly self-regulating, in that we amortize the overall moderation cost of the system across thousands of teeny-tiny slices of effort contributed by regular, everyday users.</blockquote>
+<blockquote>We designed the <a href="http://stackexchange.com/sites">Stack Exchange network</a> engine to be mostly self-regulating, in that we amortize the overall moderation cost of the system across thousands of teeny-tiny slices of effort contributed by regular, everyday users.</blockquote>
 
 
 That’s _not_ empty rhetoric - on a site the size of Stack Overflow, it’s **absolutely essential**. Geoff Dalgas came up with the design for the new review system based on his observations of wikiHow’s [Community Dashboard](http://www.wikihow.com/Special:CommunityDashboard): individual tasks, each focused on a specific need with specific actions to be taken and specific guidance provided for new users. The philosophy: don’t just give people stuff to do - help them learn how to do it.

--- a/_posts/2013-06-25-the-war-of-the-closes.markdown
+++ b/_posts/2013-06-25-the-war-of-the-closes.markdown
@@ -53,7 +53,7 @@ It _is_ off-putting to be told that your question is "not constructive".  To 
 **Ironically, we picked those terms _explicitly because they were nicer ways to convey what we meant. _**And they _were__ _nicer than, "You're kind of ranting and being a jackass," or, "No one can answer that ambiguous nonsense."  But so is prefacing my feedback to my wife with:
 
 
-<blockquote>**_It could be just me, but I feel_** like you're acting completely nutballs crazy.</blockquote>
+<blockquote><strong><em>It could be just me, but I feel</em></strong> like you're acting completely nutballs crazy.</blockquote>
 
 
 In both cases, we've gotten nicer than we started, but we're still pretty far shy of where someone might actually _accept our feedback_.

--- a/_posts/2015-01-27-targeted-jobs-for-stack-overflow.markdown
+++ b/_posts/2015-01-27-targeted-jobs-for-stack-overflow.markdown
@@ -18,7 +18,7 @@ tags:
 Stack Overflow Careers was announced [five years ago](http://blog.stackoverflow.com/2009/10/introducing-stack-overflow-careers/) with a simple mission statement:
 
 
-<blockquote>We believe that **every professional programmer should have a job they love**</blockquote>
+<blockquote>We believe that <strong>every professional programmer should have a job they love</strong></blockquote>
 
 
 To help you find a job you love, we need to match you with the right job at the right time. We do that by [helping you create a profile that brings the right employers to you](http://blog.stackoverflow.com/2011/02/careers-2-0-launches/), and by showing you relevant job ads from our [job board](http://careers.stackoverflow.com/jobs) on Stack Overflow. With [over 6,000 companies](https://careers.stackoverflow.com/companies) that advertise on Stack Overflow Careers, we're getting closer to our goal of having a great job for every developer.


### PR DESCRIPTION
I individually inspected every Markdown file containing a `<blockquote>`
tag, and either:
- Ignored the post if there was no formatting and no paragraph breaks
  within the blockquote
- Changed the formatting to pure HTML tags if it was a single-paragraph
  blockquote (to avoid extra vertical space after the auto-generated
  `<p>` tags if it was a Markdown quote)
- Changed the `<blockquote>` tags to angle brackets

I have inspected the rendered output for each of the changed posts to
verify that the changes give the right result.

With this second commit (first: #b851241), I've now covered all the
posts that contain a `<blockquote>` tag. There may be some stray posts
left over, but I think this covers nearly all cases.
