### PR TITLE
Fix lots of Markdown escaping issues

### DIFF
--- a/_posts/2008-09-21-what-was-stack-overflow-built-with.markdown
+++ b/_posts/2008-09-21-what-was-stack-overflow-built-with.markdown
@@ -34,52 +34,52 @@ This question has been covered in some detail in our [podcasts](http://blog.stac
 <tr >
 <td >framework
 </td>
-<td >[Microsoft ASP.NET](http://en.wikipedia.org/wiki/ASP.NET)
+<td ><a href="http://en.wikipedia.org/wiki/ASP.NET">Microsoft ASP.NET</a>
 </td></tr>
 <tr >
 <td >language
 </td>
-<td >[C#](http://en.wikipedia.org/wiki/C_Sharp_(programming_language))
+<td ><a href="http://en.wikipedia.org/wiki/C_Sharp_(programming_language">C#</a>
 </td></tr>
 <tr >
 <td >development environment
 </td>
-<td >[Visual Studio](http://msdn.microsoft.com/en-us/vstudio/default.aspx)
+<td ><a href="http://msdn.microsoft.com/en-us/vstudio/default.aspx">Visual Studio</a>
 </td></tr>
 <tr >
 <td >web framework
 </td>
-<td >[ASP.NET MVC](http://www.asp.net/mvc/)
+<td ><a href="http://www.asp.net/mvc/">ASP.NET MVC</a>
 </td></tr>
 <tr >
 <td >browser framework
 </td>
-<td >[jQuery](http://jquery.com/)
+<td ><a href="http://jquery.com/">jQuery</a>
 </td></tr>
 <tr >
 <td >database
 </td>
-<td >[SQL Server 2008](http://msdn.microsoft.com/en-us/sqlserver/default.aspx)
+<td ><a href="http://msdn.microsoft.com/en-us/sqlserver/default.aspx">SQL Server 2008</a>
 </td></tr>
 <tr >
 <td >data access layer
 </td>
-<td >[LINQ to SQL](http://msdn.microsoft.com/en-us/library/bb425822.aspx)
+<td ><a href="http://msdn.microsoft.com/en-us/library/bb425822.aspx">LINQ to SQL</a>
 </td></tr>
 <tr >
 <td >source control
 </td>
-<td >[Subversion](http://en.wikipedia.org/wiki/Subversion_(software)) (now [Mercurial through Kiln](http://blog.stackoverflow.com/2010/04/stack-overflow-and-dvcs/))
+<td ><a href="http://en.wikipedia.org/wiki/Subversion_(software)">Subversion</a> (now <a href="http://blog.stackoverflow.com/2010/04/stack-overflow-and-dvcs/">Mercurial through Kiln</a>)
 </td></tr>
 <tr >
 <td >compare tool
 </td>
-<td >[Beyond Compare](http://www.scootersoftware.com/index.php?from=codinghorror)
+<td ><a href="http://www.scootersoftware.com/index.php?from=codinghorror">Beyond Compare</a>
 </td></tr>
 <tr >
 <td >source control integration
 </td>
-<td >[VisualSVN](http://www.visualsvn.com/) (now, [VisualHg](http://visualhg.codeplex.com/)) 
+<td ><a href="http://www.visualsvn.com/">VisualSVN</a> (now, <a href="http://visualhg.codeplex.com/">VisualHg</a>)
 </td></tr>
 </table>
 

--- a/_posts/2008-12-01-why-cant-i-accept-my-own-answer.markdown
+++ b/_posts/2008-12-01-why-cant-i-accept-my-own-answer.markdown
@@ -99,7 +99,7 @@ So in the typical case, you'll have this:
 
 <table >
 <tr >
-<td >_Question_
+<td ><em>Question</em>
 </td></tr>
 <tr >
 <td >Community Selected Best Answer (votes)
@@ -114,7 +114,7 @@ But you might also have this:
 
 <table >
 <tr >
-<td >_Question_
+<td ><em>Question</em>
 </td></tr>
 <tr >
 <td >Owner Selected Best Answer (accepted)

--- a/_posts/2009-01-12-new-stack-overflow-server-glamour-shots.markdown
+++ b/_posts/2009-01-12-new-stack-overflow-server-glamour-shots.markdown
@@ -71,14 +71,14 @@ The 1U web tier servers are modest:
 <tr >
 <td >2
 </td>
-<td > eBay [drive brackets](http://www.codinghorror.com/blog/archives/001200.html)
+<td > eBay <a href="http://www.codinghorror.com/blog/archives/001200.html">drive brackets</a>
 </td>
 <td >$50
 </td></tr>
 <tr >
 <td >2
 </td>
-<td >500 GB [datacenter hard drives](http://www.newegg.com/Product/Product.aspx?Item=N82E16822136143), mirrored
+<td >500 GB <a href="http://www.newegg.com/Product/Product.aspx?Item=N82E16822136143">datacenter hard drives</a>, mirrored
 </td>
 <td >$160
 </td></tr>
@@ -127,14 +127,14 @@ The 2U database tier server is considerably beefier:
 <tr >
 <td >6
 </td>
-<td >eBay [drive brackets](http://www.codinghorror.com/blog/archives/001200.html)
+<td >eBay <a href="http://www.codinghorror.com/blog/archives/001200.html">drive brackets</a>
 </td>
 <td >$150
 </td></tr>
 <tr >
 <td >6
 </td>
-<td >500 GB [datacenter hard drives](http://www.newegg.com/Product/Product.aspx?Item=N82E16822136143), RAID 10
+<td >500 GB <a href="http://www.newegg.com/Product/Product.aspx?Item=N82E16822136143">datacenter hard drives</a>, RAID 10
 </td>
 <td >$480
 </td></tr>
@@ -177,9 +177,9 @@ So, in a nutshell, for around **$6,000** we'll end up with the following:
 
 <table >
 <tr >
-<td width="300" >_Web Tier_
+<td width="300" ><em>Web Tier</em>
 </td>
-<td width="300" >_Database Tier_
+<td width="300" ><em>Database Tier</em>
 </td></tr>
 <tr >
 <td >two servers

--- a/_posts/2009-01-25-new-stack-overflow-servers-ready.markdown
+++ b/_posts/2009-01-25-new-stack-overflow-servers-ready.markdown
@@ -182,8 +182,7 @@ I also did a quick run of [SQLIOSim](http://support.microsoft.com/kb/231619), wh
 
 
 
->
-**SQLIOSim will generate sufficient IO requests to overwhelm almost any disk subsystem.** The long IO message from the simulator are normal. Although this does tell you that at some point the disks won't keep up.
+<blockquote><strong>SQLIOSim will generate sufficient IO requests to overwhelm almost any disk subsystem.</strong> The long IO message from the simulator are normal. Although this does tell you that at some point the disks won't keep up.</blockquote>
 
 
 

--- a/_posts/2009-02-17-specialist-badge-implemented.markdown
+++ b/_posts/2009-02-17-specialist-badge-implemented.markdown
@@ -34,12 +34,12 @@ There are two levels:
 <tr >
 <td >Silver
 </td>
-<td >**400** upvotes
+<td ><strong>400</strong> upvotes
 </td></tr>
 <tr >
 <td >Gold
 </td>
-<td >**1000** upvotes
+<td ><strong>1000</strong> upvotes
 </td></tr>
 </table>
 

--- a/_posts/2009-02-20-our-backup-strategy-inexpensive-nas.markdown
+++ b/_posts/2009-02-20-our-backup-strategy-inexpensive-nas.markdown
@@ -83,7 +83,7 @@ The downside of picking a low end NAS is speed. The relatively anemic 500 MHz em
 
 <table width="400" >
 <tr >
-<td colspan="2" >**1 file; 6.06 GB**</tr>
+<td colspan="2" ><strong>1 file; 6.06 GB</strong></tr>
 <tr >
 <td >read
 <td >21.0 MB/sec</tr>
@@ -93,7 +93,7 @@ The downside of picking a low end NAS is speed. The relatively anemic 500 MHz em
 <tr >
 <td colspan="2" ></tr>
 <tr >
-<td colspan="2" >**5,784 files; 1,114 folders; 355 MB**</tr>
+<td colspan="2" ><strong>5,784 files; 1,114 folders; 355 MB</strong></tr>
 <tr >
 <td >read
 <td >2.46 MB/sec</tr>

--- a/_posts/2009-05-31-the-stack-overflow-trilogy.markdown
+++ b/_posts/2009-05-31-the-stack-overflow-trilogy.markdown
@@ -21,70 +21,46 @@ I've always envisioned the Stack Overflow story as a trilogy. You know, like **S
 <table >
 <tr >
 
-<td >![star-wars-poster](/images/wordpress/star-wars-poster1.jpg)
+<td style="width: 40%;"><img src="/images/wordpress/star-wars-poster1.jpg" alt="star-wars-poster"></td>
 
 <td style="padding-left:10px;" valign="top" >
-[![](http://stackoverflow.com/content/stackoverflow/img/logo.png)](http://stackoverflow.com)  
+<a href="http://stackoverflow.com"><img src="http://stackoverflow.com/content/stackoverflow/img/logo.png"></a>
 
+<p><h2><a href="http://stackoverflow.com">stackoverflow.com</a></h2></p>
 
+<p>For <strong>programmers</strong></p>
 
-## [stackoverflow.com](http://stackoverflow.com)
+<p>The first. The fondly remembered classic. A model for so many sci-fi movies that followed.</p>
 
-
-
-
-For **programmers**
-
-
-
-
-The first. The fondly remembered classic. A model for so many sci-fi movies that followed.
-
+</td>
 
 </tr>
 <tr >
 
-<td >![star-wars-empire-strikes-back-poster](/images/wordpress/star-wars-empire-strikes-back-poster1.jpg)
+<td ><img src="/images/wordpress/star-wars-empire-strikes-back-poster1.jpg" alt="star-wars-empire-strikes-back-poster"></td>
 
 <td style="padding-left:10px;" valign="top" >
-[![](http://serverfault.com/content/serverfault/img/logo.png)](http://serverfault.com)  
+<a href="http://serverfault.com"><img src="http://serverfault.com/content/serverfault/img/logo.png"></a>
 
+<p><h2><a href="http://serverfault.com">serverfault.com</a></h2></p>
 
+<p>For <strong>system administrators</strong> and <strong>desktop support professionals</strong></p>
 
-## [serverfault.com](http://serverfault.com)
-
-
-
-
-For **system administrators** and **desktop support professionals**
-
-
-
-
-A darker, more serious movie. Some say the best in the series.
-
+<p>A darker, more serious movie. Some say the best in the series.</p>
 
 </tr>
 <tr >
 
-<td >![star-wars-return-of-the-jedi-poster](/images/wordpress/star-wars-return-of-the-jedi-poster1.jpg)
+<td ><img src="/images/wordpress/star-wars-return-of-the-jedi-poster1.jpg" alt="star-wars-return-of-the-jedi-poster"></td>
 
 <td style="padding-left:10px;" valign="top" >
-[![superuser-temp-logo](http://superuser.com/content/superuser/img/logo.png)](http://superuser.com)  
+<a href="http://superuser.com"><img src="http://superuser.com/content/superuser/img/logo.png" alt="superuser-temp-logo"></a>
 
+<p><h3><a href="http://superuser.com">superuser.com</a></h3></p>
 
+<p>For <strong>computer enthusiasts</strong> and <strong>power users</strong></p>
 
-## [superuser.com](http://superuser.com)
-
-
-
-
-For **computer enthusiasts** and **power users**
-
-
-
-
-One word: _ewoks_. But also, Leia in a bikini. Still canon, but little odder than the earlier movies. In other words, things are going to get a little .. crazy .. in the finale.
+<p>One word: <em>ewoks</em>. But also, Leia in a bikini. Still canon, but little odder than the earlier movies. In other words, things are going to get a little .. crazy .. in the finale.</p>
 
 
 </tr>

--- a/_posts/2009-06-16-the-perfect-web-spider-storm.markdown
+++ b/_posts/2009-06-16-the-perfect-web-spider-storm.markdown
@@ -51,18 +51,18 @@ Geoff ran a few queries in [Log Parser](http://www.microsoft.com/downloads/detai
 
 <table width="600" >
 <tr >
-<td >**IP**
-<td >**User-Agent**
-<td align="right" >**Requests**
-<td align="right" >**Bytes Served**</tr>
+<td ><strong>IP</strong>
+<td ><strong>User-Agent</strong>
+<td align="right" ><strong>Requests</strong>
+<td align="right" ><strong>Bytes Served</strong></tr>
 <tr >
 <td >72.30.78.240
-<td >[Yahoo! Slurp/3.0](http://help.yahoo.com/help/us/ysearch/slurp)
+<td ><a href="http://help.yahoo.com/help/us/ysearch/slurp">Yahoo! Slurp/3.0</a>
 <td align="right" >56,331
 <td align="right" >1,124,861,780</tr>
 <tr >
 <td >66.249.68.109
-<td >[Googlebot/2.1](http://www.google.com/bot.html)
+<td ><a href="http://www.google.com/bot.html">Googlebot/2.1</a>
 <td align="right" >56,579
 <td align="right" >773,418,834</tr>
 <tr >

--- a/_posts/2009-06-28-cmon-get-meta.markdown
+++ b/_posts/2009-06-28-cmon-get-meta.markdown
@@ -109,35 +109,6 @@ It's also looking more and more like [meta will replace our UserVoice site](http
 
 
 
-<table >
-<tr >
-
-<td >
-
-
-</td>
-
-<td >
-
-
-</td>
-</tr>
-<tr >
-
-<td >
-
-
-</td>
-
-<td >
-
-
-</td>
-</tr>
-</table>
-
-
-
 Kyle had some ideas about changes to the SO engine to help it adapt from the Q&A; format discussion:
 
 

--- a/_posts/2009-07-29-stack-overflow-search-now-61-less-crappy.markdown
+++ b/_posts/2009-07-29-stack-overflow-search-now-61-less-crappy.markdown
@@ -24,30 +24,22 @@ Well, we rolled up our sleeves and increased search quality a whole ten percent 
 
 
 
+<ol>
+  <li>
+    Search now <strong><em>heavily</em> weights title</strong> in the results, since people seemed to really like that approach. This is currently used on the /ask page, which does a title-exclusive search when you tab away (onblur) the title field.
+  </li>
+  <li>
+    <p>Any individual search terms which map directly to the top 40 tags will be <strong>auto-converted to tag searches</strong>. So if you enter</p>
 
+    <p>c++ entities</p>
 
-  1. Search now **_heavily_ weights title** in the results, since people seemed to really like that approach. This is currently used on the /ask page, which does a title-exclusive search when you tab away (onblur) the title field.
+    <p>it will convert to</p>
 
+    <p>[c++] entities</p>
 
-
-
-  2. Any individual search terms which map directly to the top 40 tags will be **auto-converted to tag searches**. So if you enter
-
-
-
-c++ entities
-
-
-
- it will convert to 
-
-
-
-[c++] entities
-
-
-
-automagically on your behalf.
+    <p>automagically on your behalf.</p>
+  </li>
+</ol>
 
 
 

--- a/_posts/2009-10-29-free-public-careers-cvs.markdown
+++ b/_posts/2009-10-29-free-public-careers-cvs.markdown
@@ -30,12 +30,12 @@ We had originally envisioned careers as a completely private subscription servic
 
 <table width="450" >
 <tr >
-<td width="100" valign="top" >**Publish CV**
+<td width="100" valign="top" ><strong>Publish CV</strong>
 </td>
 <td >free, public CVs for any working programmer who wants one, at the URL of their choice.
 </td></tr>
 <tr >
-<td width="100" valign="top" >**File CV**
+<td width="100" valign="top" ><strong>File CV</strong>
 </td>
 <td >subscribe for a nominal fee, and make your private CV visible to and searchable by hiring managers
 </td></tr>

--- a/_posts/2009-11-05-our-amazon-advertising-experiment.markdown
+++ b/_posts/2009-11-05-our-amazon-advertising-experiment.markdown
@@ -73,10 +73,10 @@ You can read the full skinny in [Portman's summary](http://blog.stackoverflow.co
 <tr >
 
 <td >
-![so-amazon-ads](/images/wordpress/so-amazon-ads.png)
+<img src="/images/wordpress/so-amazon-ads.png" alt="so-amazon-ads">
 
 <td >
-![so-amazon-ads-2](/images/wordpress/so-amazon-ads-2.png)
+<img src="/images/wordpress/so-amazon-ads-2.png" alt="so-amazon-ads-2">
 </tr>
 </table>
 

--- a/_posts/2010-01-01-stack-overflow-gives-back.markdown
+++ b/_posts/2010-01-01-stack-overflow-gives-back.markdown
@@ -26,60 +26,6 @@ First and foremost, our **community moderators**. They, more than anyone, set th
 
 
 
-<table width="500" >
-<tr >
-
-<td >
-
-
-<td >
-
-</tr>
-<tr >
-
-<td >
-
-
-<td >
-
-</tr>
-<tr >
-
-<td >
-
-
-<td >
-
-</tr>
-<tr >
-
-<td >
-
-
-<td >
-
-</tr>
-<tr >
-
-<td >
-
-
-<td >
-
-</tr>
-<tr >
-
-<td >
-
-
-<td >
-
-</tr>
-</table>
-
-
-
-
 As a gesture of thanks for their contributions this year, Stack Overflow offered to **make a donation to the charity or nonprofit of their choice**. I'm happy to report that through our moderators, the following donations were made:
 
 

--- a/_posts/2010-01-29-open-source-ad-stats.markdown
+++ b/_posts/2010-01-29-open-source-ad-stats.markdown
@@ -26,12 +26,12 @@ Visit the [ad summary page](http://rads.stackoverflow.com/ossads/all), and mouse
 <tr >
 
 <td >
-[![](http://blog.stackoverflow.com/wp-content/uploads/oss-ad-stats-1.png)](http://rads.stackoverflow.com/ossads/all)
+<a href="http://rads.stackoverflow.com/ossads/all"><img src="http://blog.stackoverflow.com/wp-content/uploads/oss-ad-stats-1.png"></a>
 
 </td>
 
 <td >
-[![](http://blog.stackoverflow.com/wp-content/uploads/oss-ad-stats-2.png)](http://rads.stackoverflow.com/ossads/all)
+<a href="http://rads.stackoverflow.com/ossads/all"><img src="http://blog.stackoverflow.com/wp-content/uploads/oss-ad-stats-2.png"></a>
 
 </td>
 </table>

--- a/_posts/2010-05-23-generalist-badge-implemented.markdown
+++ b/_posts/2010-05-23-generalist-badge-implemented.markdown
@@ -45,59 +45,64 @@ The top 40 tag list is surprisingly diverse across the entire Trilogy. Just chec
 <tr >
 
 <td >
-1. c#
-2. java 
-3. .net
-4. php
-5. asp.net
-6. javascript
-7. c++
-8. jquery
-9. iphone
-10. python
+  <ol>
+    <li>c#</li>
+    <li>java </li>
+    <li>.net</li>
+    <li>php</li>
+    <li>asp.net</li>
+    <li>javascript</li>
+    <li>c++</li>
+    <li>jquery</li>
+    <li>iphone</li>
+    <li>python</li>
+  </ol>
+</td>
+
+<td >
+  <ol start="11">
+    <li>sql</li>
+    <li>mysql</li>
+    <li>html</li>
+    <li>sql-server</li>
+    <li>ruby-on-rails</li>
+    <li>c</li>
+    <li>asp.net-mvc</li>
+    <li>css</li>
+    <li>wpf</li>
+    <li>objective-c</li>
+  </ol>
+</td>
+
+<td >
+  <ol start="21">
+    <li>windows</li>
+    <li>xml</li>
+    <li>ruby</li>
+    <li>database</li>
+    <li>best-practices</li>
+    <li>vb.net</li>
+    <li>android</li>
+    <li>visual-studio</li>
+    <li>ajax</li>
+    <li>regex</li>
+  </ol>
 
 </td>
 
 <td >
-11. sql
-12. mysql
-13. html
-14. sql-server
-15. ruby-on-rails
-16. c
-17. asp.net-mvc
-18. css
-19. wpf
-20. objective-c
-
-</td>
-
-<td >
-21. windows
-22. xml
-23. ruby
-24. database
-25. best-practices
-26. vb.net
-27. android
-28. visual-studio
-29. ajax
-30. regex
-
-</td>
-
-<td >
-31. linux
-32. winforms
-33. django
-34. iphone-sdk
-35. visual-studio-2008
-36. beginner
-37. web-development
-38. flex
-39. subjective
-40. flash
-
+  <ol start="31">
+    <li>linux</li>
+    <li>winforms</li>
+    <li>django</li>
+    <li>iphone-sdk</li>
+    <li>visual-studio-2008</li>
+    <li>beginner</li>
+    <li>web-development</li>
+    <li>flex</li>
+    <li>subjective</li>
+    <li>flash</li>
+  </ol>
 </td>
 </tr>
 </table>

--- a/_posts/2010-06-16-area-51-we-come-in-peace.markdown
+++ b/_posts/2010-06-16-area-51-we-come-in-peace.markdown
@@ -54,10 +54,10 @@ Z@rpqf says, "Build awesome sites!"
 <tbody >
 <tr >
 
-<td width="319" style="width: 239.4pt; border: 1pt solid black; padding: 0in 5.4pt;" valign="top" >If you've got a great idea for a site, [visit Area   51](http://area51.stackexchange.com/). We've got [6.7 million people](http://www.quantcast.com/p-c1rF4kxgLUzNc) visiting us   each month, so we've got the audience. We've raised enough money to make   Stack Exchange absolutely free, so all we need is ideas. Browse through our   proposals to help get the site ideas you love off to a strong start.
+<td width="319" style="width: 239.4pt; border: 1pt solid black; padding: 0in 5.4pt;" valign="top" >If you've got a great idea for a site, <a href="http://area51.stackexchange.com/">visit Area 51</a>. We've got <a href="http://www.quantcast.com/p-c1rF4kxgLUzNc">6.7 million people</a> visiting us   each month, so we've got the audience. We've raised enough money to make   Stack Exchange absolutely free, so all we need is ideas. Browse through our   proposals to help get the site ideas you love off to a strong start.
 </td>
 
-<td width="319" style="width: 239.4pt; padding: 0in 5.4pt;" valign="top" >![art-vote.png](file:///C:/Users/ROBERT/AppData/Local/Temp/msohtmlclip1/01/clip_image002.gif)
+<td width="319" style="width: 239.4pt; padding: 0in 5.4pt;" valign="top" ><img src="file:///C:/Users/ROBERT/AppData/Local/Temp/msohtmlclip1/01/clip_image002.gif" alt="art-vote.png">
 </td>
 </tr>
 </tbody>

--- a/_posts/2010-07-11-summer-2010-moderator-appointments.markdown
+++ b/_posts/2010-07-11-summer-2010-moderator-appointments.markdown
@@ -25,22 +25,10 @@ Due to a continual and ever-growing stream of moderator flags on [the classic tr
 
 
 
-<table cellpadding="2" width="450" cellspacing="2" >
-<tr >
 
-<td >
-             
-             
 
-</td>
 
-<td >
-             
-             
 
-</td>
-</tr>
-</table>
 
 (came in 3rd and 4th in [our 2010 election](http://blog.stackoverflow.com/2010/02/stack-overflow-2010-moderator-election-results/))
 

--- a/_posts/2010-09-09-announcer-booster-and-publicist-badges.markdown
+++ b/_posts/2010-09-09-announcer-booster-and-publicist-badges.markdown
@@ -18,19 +18,19 @@ We just rolled out three new badges to encourage **sharing worthy questions**:
 
 <table >
 <tr >
-<td valign="top" >![announcer badge (bronze)](/images/wordpress/announcer-badge.png)
+<td valign="top" ><img src="/images/wordpress/announcer-badge.png" alt="announcer badge (bronze)">
 </td>
-<td valign="top" >Shared a link to a question that was visited by **25** unique IP addresses in **3** days
+<td valign="top" >Shared a link to a question that was visited by <strong>25</strong> unique IP addresses in <strong>3</strong> days
 </td></tr>
 <tr >
-<td valign="top" >![booster badge (silver)](/images/wordpress/booster-badge.png)
+<td valign="top" ><img src="/images/wordpress/booster-badge.png" alt="booster badge (silver)">
 </td>
-<td valign="top" >Shared a link to a question that was visited by **300** unique IP addresses in **4** days
+<td valign="top" >Shared a link to a question that was visited by <strong>300</strong> unique IP addresses in <strong>4</strong> days
 </td></tr>
 <tr >
-<td valign="top" >![publicist badge (gold)](/images/wordpress/publicist-badge.png)
+<td valign="top" ><img src="/images/wordpress/publicist-badge.png" alt="publicist badge (gold)">
 </td>
-<td valign="top" >Shared a link to a question that was visited by **1,000** unique IP addresses in **5** days
+<td valign="top" >Shared a link to a question that was visited by <strong>1,000</strong> unique IP addresses in <strong>5</strong> days
 </td></tr>
 </table>
 

--- a/_posts/2010-09-10-server-fault-chat-now-available.markdown
+++ b/_posts/2010-09-10-server-fault-chat-now-available.markdown
@@ -25,21 +25,21 @@ You may remember we [rolled out per-site metas](http://blog.stackoverflow.com/20
 <table cellpadding="4" width="600" cellspacing="4" >
 <tr >
 
-<td >`serverfault.com`
+<td ><code>serverfault.com</code>
 </td>
 <td >Q&A; for professional system administrators
 </td>
 </tr>
 <tr >
 
-<td >`meta.serverfault.com`
+<td ><code>meta.serverfault.com</code>
 </td>
 <td >community organization and discussion about the site itself
 </td>
 </tr>
 <tr >
 
-<td >`chat.serverfault.com`
+<td ><code>chat.serverfault.com</code>
 </td>
 <td >real time chat "third place" for regulars
 </td>

--- a/_posts/2010-09-16-super-user-chat-now-available.markdown
+++ b/_posts/2010-09-16-super-user-chat-now-available.markdown
@@ -26,21 +26,21 @@ It's only appropriate that, after [adding per-site metas](http://blog.stackoverf
 <table cellpadding="4" width="600" cellspacing="4" >
 <tr >
 
-<td >`superuser.com`
+<td ><code>superuser.com</code>
 </td>
 <td >Q&A; for computer enthusiasts and power users
 </td>
 </tr>
 <tr >
 
-<td >`meta.superuser.com`
+<td ><code>meta.superuser.com</code>
 </td>
 <td >community organization and discussion about the site itself
 </td>
 </tr>
 <tr >
 
-<td >`chat.superuser.com`
+<td ><code>chat.superuser.com</code>
 </td>
 <td >real time chat "third place" for regulars
 </td>

--- a/_posts/2010-09-23-flair-now-even-flairier.markdown
+++ b/_posts/2010-09-23-flair-now-even-flairier.markdown
@@ -56,37 +56,37 @@ And, yes, flair works the same on every [Stack Exchange network site](http://sta
 <table cellpadding="4" width="430" cellspacing="4" >
 <tr >
 
-<td >[![](http://serverfault.com/users/flair/301.png)](http://serverfault.com/users/301/dave-cheney)
+<td ><a href="http://serverfault.com/users/301/dave-cheney"><img src="http://serverfault.com/users/flair/301.png"></a>
 </td>
 
-<td >[![](http://meta.stackoverflow.com/users/flair/22164.png)](http://meta.stackoverflow.com/users/22164/thetxi)
-</td>
-</tr>
-
-<tr >
-
-<td >[![](http://superuser.com/users/flair/13241.png)](http://superuser.com/users/13241/josh-k)
-</td>
-
-<td >[![](http://webapps.stackexchange.com/users/flair/324.png)](http://webapps.stackexchange.com/users/324/neo)
+<td ><a href="http://meta.stackoverflow.com/users/22164/thetxi"><img src="http://meta.stackoverflow.com/users/flair/22164.png"></a>
 </td>
 </tr>
 
 <tr >
 
-<td >[![](http://gaming.stackexchange.com/users/flair/32.png)](http://gaming.stackexchange.com/users/32/mag-roader)
+<td ><a href="http://superuser.com/users/13241/josh-k"><img src="http://superuser.com/users/flair/13241.png"></a>
 </td>
 
-<td >[![](http://webmasters.stackexchange.com/users/flair/26.png)](http://webmasters.stackexchange.com/users/26/artlung)
+<td ><a href="http://webapps.stackexchange.com/users/324/neo"><img src="http://webapps.stackexchange.com/users/flair/324.png"></a>
 </td>
 </tr>
 
 <tr >
 
-<td >[![](http://answers.onstartups.com/users/flair/1796.png)](http://answers.onstartups.com/users/1796/jeff-oresik)
+<td ><a href="http://gaming.stackexchange.com/users/32/mag-roader"><img src="http://gaming.stackexchange.com/users/flair/32.png"></a>
 </td>
 
-<td >[![](http://android.stackexchange.com/users/flair/3.png)](http://android.stackexchange.com/users/3/othermichael)
+<td ><a href="http://webmasters.stackexchange.com/users/26/artlung"><img src="http://webmasters.stackexchange.com/users/flair/26.png"></a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://answers.onstartups.com/users/1796/jeff-oresik"><img src="http://answers.onstartups.com/users/flair/1796.png"></a>
+</td>
+
+<td ><a href="http://android.stackexchange.com/users/3/othermichael"><img src="http://android.stackexchange.com/users/flair/3.png"></a>
 </td>
 </tr>
 </table>
@@ -101,24 +101,24 @@ And if you're an avid user, active on multiple sites, we have an extra-special s
 <tr >
 
 <td >
-![](http://stackexchange.com/users/flair/357a269566b44ab99bbd502d6ad0b1ce.png)
+<img src="http://stackexchange.com/users/flair/357a269566b44ab99bbd502d6ad0b1ce.png">
 
 </td>
 
 <td >
-![](http://stackexchange.com/users/flair/30498037168a4055a8490c31c2b1d863.png)
+<img src="http://stackexchange.com/users/flair/30498037168a4055a8490c31c2b1d863.png">
 
 </td>
 </tr>
 <tr >
 
 <td >
-![](http://stackexchange.com/users/flair/c23cf04a6809424b833d19e6d55f2e8d.png)
+<img src="http://stackexchange.com/users/flair/c23cf04a6809424b833d19e6d55f2e8d.png">
 
 </td>
 
 <td >
-![](http://stackexchange.com/users/flair/5091e12f1fdc49d9aec229814923e1c6.png)
+<img src="http://stackexchange.com/users/flair/5091e12f1fdc49d9aec229814923e1c6.png">
 
 </td>
 </tr>

--- a/_posts/2010-10-19-vote-early-vote-often.markdown
+++ b/_posts/2010-10-19-vote-early-vote-often.markdown
@@ -101,10 +101,10 @@ These new voting badges will be applied retroactively, and complement the existi
 >
 Let each citizen remember at the moment he is offering his vote that he is not making a present or a compliment to please an individual -- or at least that he ought not so to do; but that he is executing one of the most solemn trusts in human society.
 
-> 
-> - Samuel Adams
-> 
-> 
+>
+> &mdash; Samuel Adams
+>
+>
 
 
 

--- a/_posts/2010-10-30-database-upgrade.markdown
+++ b/_posts/2010-10-30-database-upgrade.markdown
@@ -19,17 +19,17 @@ As part of our [datacenter migration](http://blog.stackoverflow.com/2010/10/data
 <tr >
 
 <td >
-**Oregon**  
-48 GB  
-2 Xeon X5470 CPUs  
+<strong>Oregon</strong><br/>
+48 GB<br/>
+2 Xeon X5470 CPUs<br/>
 8 total cores @ 3.33 Ghz
 
 </td>
 
 <td >
-**NYC**  
-64 GB  
-2 Xeon X5680 CPUs  
+<strong>NYC</strong><br/>
+64 GB<br/>
+2 Xeon X5680 CPUs<br/>
 12 total cores @ 3.33 GHz
 
 </td>

--- a/_posts/2010-11-03-the-horror-of-no-answer-revival-and-necromancer.markdown
+++ b/_posts/2010-11-03-the-horror-of-no-answer-revival-and-necromancer.markdown
@@ -60,14 +60,14 @@ We've also introduced a new bronze badge, Revival, to complement the existing si
 <table >
 <tr >
 
-<td >![Revival badge (bronze)](/images/wordpress/badge-revival.png)
+<td ><img src="/images/wordpress/badge-revival.png" alt="Revival badge (bronze)">
 </td>
 
 <td >Answered more than 30 days later as first answer scoring 2 or more
 </td>
 </tr>
 
-<td >![Necromancer badge (silver)](/images/wordpress/badge-necromancer.png)
+<td ><img src="/images/wordpress/badge-necromancer.png" alt="Necromancer badge (silver)">
 </td>
 
 <td >

--- a/_posts/2010-11-09-stack-overflow-homepage-changes.markdown
+++ b/_posts/2010-11-09-stack-overflow-homepage-changes.markdown
@@ -51,7 +51,7 @@ Next, apply the following score formula to the remaining questions:
 <table cellpadding="4" width="600" cellspacing="4" >
 <tr >
 
-<td >your [interesting tags](http://blog.stackoverflow.com/2008/10/expressing-your-tag-preferences/)
+<td >your <a href="http://blog.stackoverflow.com/2008/10/expressing-your-tag-preferences/">interesting tags</a>
 </td>
 
 <td >+1,500 per interesting tag, up to +2,000 total

--- a/_posts/2010-12-09-talkative-and-precognitive-badges.markdown
+++ b/_posts/2010-12-09-talkative-and-precognitive-badges.markdown
@@ -37,8 +37,8 @@ But it doesn't matter what _I_ think. Everyone should check chat out for themsel
 
 <table >
 <tr >
-<td >![talkative badge](/images/wordpress/badge-talkative.png)
-<td >Posted 10 messages, with 1 or more starred, in [chat](http://chat.stackexchange.com)</tr>
+<td ><img src="/images/wordpress/badge-talkative.png" alt="talkative badge">
+<td >Posted 10 messages, with 1 or more starred, in <a href="http://chat.stackexchange.com">chat</a></tr>
 </table>
 
 To earn this badge, you'll need to post 10 chat messages in a room -- and one of them must be starred by another fellow chat user user. Go be interesting!
@@ -57,8 +57,8 @@ The success of this community process depends, as they all do, on participation.
 
 <table >
 <tr >
-<td >![precognitive badge](/images/wordpress/badge-precognitive.png)
-<td >Followed the [Area 51](http://area51.stackexchange.com) proposal for this site before it entered the commitment phase</tr>
+<td ><img src="/images/wordpress/badge-precognitive.png" alt="precognitive badge">
+<td >Followed the <a href="http://area51.stackexchange.com">Area 51</a> proposal for this site before it entered the commitment phase</tr>
 </table>
 
 This badge, like Area 51 itself, is all about the future. To achieve this badge, you'll have to **follow an early Area 51 site proposal** that eventually succeeds and go to beta -- hopefully with your active assistance. In other words, the only way to earn the Precognitive badge on a site is ... _before the site even exists!_ Spooky, right?

--- a/_posts/2011-01-12-twitter-question-feeds-for-stack-exchange.markdown
+++ b/_posts/2011-01-12-twitter-question-feeds-for-stack-exchange.markdown
@@ -29,311 +29,311 @@ With that in mind, we've set up the following Twitter accounts to publish the mo
 <tr >
 
 <td >
-[![Stack Exchange site](http://blog.stackoverflow.com/wp-content/uploads/se-logo2.png)](http://stackexchange.com/sites)
+<a href="http://stackexchange.com/sites"><img src="http://blog.stackoverflow.com/wp-content/uploads/se-logo2.png" alt="Stack Exchange site"></a>
 
 </td>
 
 
 <td >
-[![Twitter account](http://blog.stackoverflow.com/wp-content/uploads/twitter-logo1.png)](https://twitter.com)
+<a href="https://twitter.com"><img src="http://blog.stackoverflow.com/wp-content/uploads/twitter-logo1.png" alt="Twitter account"></a>
 
 </td>
 
 <tr >
 
-<td >[Android](http://android.stackexchange.com)
+<td ><a href="http://android.stackexchange.com">Android</a>
 </td>
 
-<td >[StackAndroid](https://twitter.com/StackAndroid)
+<td ><a href="https://twitter.com/StackAndroid">StackAndroid</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[Apple](http://apple.stackexchange.com)
+<td ><a href="http://apple.stackexchange.com">Apple</a>
 </td>
 
-<td >[StackApple](https://twitter.com/StackApple)
-</td>
-</tr>
-
-<tr >
-
-<td >[StackApps](http://stackapps.com)
-</td>
-
-<td >[StackApps](https://twitter.com/StackApps)
+<td ><a href="https://twitter.com/StackApple">StackApple</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[Audio Recording & Production](http://audio.stackexchange.com)
+<td ><a href="http://stackapps.com">StackApps</a>
 </td>
 
-<td >[StackAudio](https://twitter.com/StackAudio)
-</td>
-</tr>
-
-<tr >
-
-<td >[Bicycles](http://bicycles.stackexchange.com)
-</td>
-
-<td >[StackBicycles](https://twitter.com/StackBicycles)
+<td ><a href="https://twitter.com/StackApps">StackApps</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[Board and Card Games](http://boardgames.stackexchange.com)
+<td ><a href="http://audio.stackexchange.com">Audio Recording & Production</a>
 </td>
 
-<td >[StackBoardGames](https://twitter.com/StackBoardGames)
-</td>
-</tr>
-
-<tr >
-
-<td >[Cooking](http://cooking.stackexchange.com)
-</td>
-
-<td >[StackCooking](https://twitter.com/StackCooking)
+<td ><a href="https://twitter.com/StackAudio">StackAudio</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[CS Theory](http://cstheory.stackexchange.com)
+<td ><a href="http://bicycles.stackexchange.com">Bicycles</a>
 </td>
 
-<td >[StackCSTheory](https://twitter.com/StackCSTheory)
-</td>
-</tr>
-
-<tr >
-
-<td >[Home Improvement](http://diy.stackexchange.com)
-</td>
-
-<td >[StackDIY](https://twitter.com/StackDIY)
+<td ><a href="https://twitter.com/StackBicycles">StackBicycles</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[English Language & Usage](http://english.stackexchange.com)
+<td ><a href="http://boardgames.stackexchange.com">Board and Card Games</a>
 </td>
 
-<td >[StackEnglish](https://twitter.com/StackEnglish)
+<td ><a href="https://twitter.com/StackBoardGames">StackBoardGames</a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://cooking.stackexchange.com">Cooking</a>
+</td>
+
+<td ><a href="https://twitter.com/StackCooking">StackCooking</a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://cstheory.stackexchange.com">CS Theory</a>
+</td>
+
+<td ><a href="https://twitter.com/StackCSTheory">StackCSTheory</a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://diy.stackexchange.com">Home Improvement</a>
+</td>
+
+<td ><a href="https://twitter.com/StackDIY">StackDIY</a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://english.stackexchange.com">English Language & Usage</a>
+</td>
+
+<td ><a href="https://twitter.com/StackEnglish">StackEnglish</a>
 </td>
 </tr>
 
 
 <tr >
 
-<td >[Database Administrators](http://dba.stackexchange.com)
+<td ><a href="http://dba.stackexchange.com">Database Administrators</a>
 </td>
 
-<td >[StackDBAs](https://twitter.com/StackDBAs)
-</td>
-</tr>
-
-<tr >
-
-<td >[Personal Finance and Money](http://money.stackexchange.com)
-</td>
-
-<td >[StackFinance](https://twitter.com/StackFinance)
+<td ><a href="https://twitter.com/StackDBAs">StackDBAs</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[Game Development](http://gamedev.stackexchange.com)
+<td ><a href="http://money.stackexchange.com">Personal Finance and Money</a>
 </td>
 
-<td >[StackGameDev](https://twitter.com/StackGameDev)
-</td>
-</tr>
-
-<tr >
-
-<td >[Gaming](http://gaming.stackexchange.com)
-</td>
-
-<td >[StackGaming](https://twitter.com/StackGaming)
+<td ><a href="https://twitter.com/StackFinance">StackFinance</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[GIS](http://gis.stackexchange.com)
+<td ><a href="http://gamedev.stackexchange.com">Game Development</a>
 </td>
 
-<td >[StackGIS](https://twitter.com/StackGIS)
-</td>
-</tr>
-
-<tr >
-
-<td >[Homebrewing](http://homebrew.stackexchange.com)
-</td>
-
-<td >[StackHomebrew](https://twitter.com/StackHomebrew)
+<td ><a href="https://twitter.com/StackGameDev">StackGameDev</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[Mathematics](http://math.stackexchange.com)
+<td ><a href="http://gaming.stackexchange.com">Gaming</a>
 </td>
 
-<td >[StackMath](https://twitter.com/StackMath)
-</td>
-</tr>
-
-<tr >
-
-<td >[OnStartups Answers](http://answers.onstartups.com)
-</td>
-
-<td >[StackOnStartups](https://twitter.com/StackOnStartups)
+<td ><a href="https://twitter.com/StackGaming">StackGaming</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[Photography](http://photo.stackexchange.com)
+<td ><a href="http://gis.stackexchange.com">GIS</a>
 </td>
 
-<td >[StackPhotos](https://twitter.com/StackPhotos)
-</td>
-</tr>
-
-<tr >
-
-<td >[Physics](http://physics.stackexchange.com)
-</td>
-
-<td >[StackPhysics](https://twitter.com/StackPhysics)
+<td ><a href="https://twitter.com/StackGIS">StackGIS</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[Programmers](http://programmers.stackexchange.com)
+<td ><a href="http://homebrew.stackexchange.com">Homebrewing</a>
 </td>
 
-<td >[StackProgrammer](https://twitter.com/StackProgrammer)
-</td>
-</tr>
-
-<tr >
-
-<td >[Electronics and Robotics](http://electronics.stackexchange.com)
-</td>
-
-<td >[StackRobots](https://twitter.com/StackRobots)
+<td ><a href="https://twitter.com/StackHomebrew">StackHomebrew</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[Role-Playing Games](http://rpg.stackexchange.com)
+<td ><a href="http://math.stackexchange.com">Mathematics</a>
 </td>
 
-<td >[StackRPG](https://twitter.com/StackRPG)
-</td>
-</tr>
-
-<tr >
-
-<td >[IT Security](http://security.stackexchange.com)
-</td>
-
-<td >[StackSecurity](https://twitter.com/StackSecurity)
+<td ><a href="https://twitter.com/StackMath">StackMath</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[Statistics](http://stats.stackexchange.com)
+<td ><a href="http://answers.onstartups.com">OnStartups Answers</a>
 </td>
 
-<td >[StackStats](https://twitter.com/StackStats)
-</td>
-</tr>
-
-<tr >
-
-<td >[TeX](http://tex.stackexchange.com)
-</td>
-
-<td >[StackTex](https://twitter.com/StackTex)
+<td ><a href="https://twitter.com/StackOnStartups">StackOnStartups</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[User Interface](http://ui.stackexchange.com)
+<td ><a href="http://photo.stackexchange.com">Photography</a>
 </td>
 
-<td >[StackUI](https://twitter.com/StackUI)
-</td>
-</tr>
-
-<tr >
-
-<td >[Ask Ubuntu](http://askubuntu.com)
-</td>
-
-<td >[StackUbuntu](https://twitter.com/StackUbuntu)
+<td ><a href="https://twitter.com/StackPhotos">StackPhotos</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[Unix and Linux](http://unix.stackexchange.com)
+<td ><a href="http://physics.stackexchange.com">Physics</a>
 </td>
 
-<td >[StackUnix](https://twitter.com/StackUnix)
-</td>
-</tr>
-
-<tr >
-
-<td >[Web Applications](http://webapps.stackexchange.com)
-</td>
-
-<td >[StackWebApps](https://twitter.com/StackWebApps)
+<td ><a href="https://twitter.com/StackPhysics">StackPhysics</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[Pro Webmasters](http://webmasters.stackexchange.com)
+<td ><a href="http://programmers.stackexchange.com">Programmers</a>
 </td>
 
-<td >[StackWebmasters](https://twitter.com/StackWebmasters)
-</td>
-</tr>
-
-<tr >
-
-<td >[WordPress](http://wordpress.stackexchange.com)
-</td>
-
-<td >[StackWordPress](https://twitter.com/StackWordPress)
+<td ><a href="https://twitter.com/StackProgrammer">StackProgrammer</a>
 </td>
 </tr>
 
 <tr >
 
-<td >[Writers](http://writers.stackexchange.com)
+<td ><a href="http://electronics.stackexchange.com">Electronics and Robotics</a>
 </td>
 
-<td >[StackWriters](https://twitter.com/StackWriters)
+<td ><a href="https://twitter.com/StackRobots">StackRobots</a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://rpg.stackexchange.com">Role-Playing Games</a>
+</td>
+
+<td ><a href="https://twitter.com/StackRPG">StackRPG</a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://security.stackexchange.com">IT Security</a>
+</td>
+
+<td ><a href="https://twitter.com/StackSecurity">StackSecurity</a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://stats.stackexchange.com">Statistics</a>
+</td>
+
+<td ><a href="https://twitter.com/StackStats">StackStats</a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://tex.stackexchange.com">TeX</a>
+</td>
+
+<td ><a href="https://twitter.com/StackTex">StackTex</a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://ui.stackexchange.com">User Interface</a>
+</td>
+
+<td ><a href="https://twitter.com/StackUI">StackUI</a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://askubuntu.com">Ask Ubuntu</a>
+</td>
+
+<td ><a href="https://twitter.com/StackUbuntu">StackUbuntu</a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://unix.stackexchange.com">Unix and Linux</a>
+</td>
+
+<td ><a href="https://twitter.com/StackUnix">StackUnix</a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://webapps.stackexchange.com">Web Applications</a>
+</td>
+
+<td ><a href="https://twitter.com/StackWebApps">StackWebApps</a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://webmasters.stackexchange.com">Pro Webmasters</a>
+</td>
+
+<td ><a href="https://twitter.com/StackWebmasters">StackWebmasters</a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://wordpress.stackexchange.com">WordPress</a>
+</td>
+
+<td ><a href="https://twitter.com/StackWordPress">StackWordPress</a>
+</td>
+</tr>
+
+<tr >
+
+<td ><a href="http://writers.stackexchange.com">Writers</a>
+</td>
+
+<td ><a href="https://twitter.com/StackWriters">StackWriters</a>
 </td>
 </tr>
 

--- a/_posts/2011-02-16-blekko-and-stack-overflow.markdown
+++ b/_posts/2011-02-16-blekko-and-stack-overflow.markdown
@@ -23,59 +23,59 @@ As [originally announced on meta](http://meta.stackoverflow.com/questions/77441/
 <tr >
 
 <td valign="top" >
-[/android](http://blekko.com/ws/+/android) 
-[/bsd](http://blekko.com/ws/+/bsd) 
-[/cloud](http://blekko.com/ws/+/cloud) 
-[/couchdb](http://blekko.com/ws/+/couchdb) 
-[/css](http://blekko.com/ws/+/css) 
-[/directx](http://blekko.com/ws/+/directx) 
-[/dotnet](http://blekko.com/ws/+/dotnet) 
-[/emacs](http://blekko.com/ws/+/emacs) 
-[/freebsd](http://blekko.com/ws/+/freebsd) 
-[/fsf](http://blekko.com/ws/+/fsf) 
+<a href="http://blekko.com/ws/+/android">/android</a><br/>
+<a href="http://blekko.com/ws/+/bsd">/bsd</a><br/>
+<a href="http://blekko.com/ws/+/cloud">/cloud</a><br/>
+<a href="http://blekko.com/ws/+/couchdb">/couchdb</a><br/>
+<a href="http://blekko.com/ws/+/css">/css</a><br/>
+<a href="http://blekko.com/ws/+/directx">/directx</a><br/>
+<a href="http://blekko.com/ws/+/dotnet">/dotnet</a><br/>
+<a href="http://blekko.com/ws/+/emacs">/emacs</a><br/>
+<a href="http://blekko.com/ws/+/freebsd">/freebsd</a><br/>
+<a href="http://blekko.com/ws/+/fsf">/fsf</a>
 
 </td>
 
 <td valign="top" >
-[/hackerspaces](http://blekko.com/ws/+/hackerspaces) 
-[/hadoop](http://blekko.com/ws/+/hadoop) 
-[/hpc](http://blekko.com/ws/+/hpc) 
-[/ipadapps](http://blekko.com/ws/+/ipadapps) 
-[/it](http://blekko.com/ws/+/it) 
-[/java](http://blekko.com/ws/+/java) 
-[/js](http://blekko.com/ws/+/js) 
-[/lego](http://blekko.com/ws/+/lego) 
-[/linux](http://blekko.com/ws/+/linux) 
-[/mongodb](http://blekko.com/ws/+/mongodb) 
+<a href="http://blekko.com/ws/+/hackerspaces">/hackerspaces</a><br/>
+<a href="http://blekko.com/ws/+/hadoop">/hadoop</a><br/>
+<a href="http://blekko.com/ws/+/hpc">/hpc</a><br/>
+<a href="http://blekko.com/ws/+/ipadapps">/ipadapps</a><br/>
+<a href="http://blekko.com/ws/+/it">/it</a><br/>
+<a href="http://blekko.com/ws/+/java">/java</a><br/>
+<a href="http://blekko.com/ws/+/js">/js</a><br/>
+<a href="http://blekko.com/ws/+/lego">/lego</a><br/>
+<a href="http://blekko.com/ws/+/linux">/linux</a><br/>
+<a href="http://blekko.com/ws/+/mongodb">/mongodb</a>
 
 </td>
 
 <td valign="top" >
-[/ms](http://blekko.com/ws/+/ms) 
-[/nosql](http://blekko.com/ws/+/nosql) 
-[/open-source](http://blekko.com/ws/+/open-source) 
-[/opengl](http://blekko.com/ws/+/opengl) 
-[/perl](http://blekko.com/ws/+/perl) 
-[/php](http://blekko.com/ws/+/php) 
-[/python](http://blekko.com/ws/+/python) 
-[/rails](http://blekko.com/ws/+/rails) 
-[/ruby](http://blekko.com/ws/+/ruby) 
-[/so](http://blekko.com/ws/+/so) 
+<a href="http://blekko.com/ws/+/ms">/ms</a><br/>
+<a href="http://blekko.com/ws/+/nosql">/nosql</a><br/>
+<a href="http://blekko.com/ws/+/open-source">/open-source</a><br/>
+<a href="http://blekko.com/ws/+/opengl">/opengl</a><br/>
+<a href="http://blekko.com/ws/+/perl">/perl</a><br/>
+<a href="http://blekko.com/ws/+/php">/php</a><br/>
+<a href="http://blekko.com/ws/+/python">/python</a><br/>
+<a href="http://blekko.com/ws/+/rails">/rails</a><br/>
+<a href="http://blekko.com/ws/+/ruby">/ruby</a><br/>
+<a href="http://blekko.com/ws/+/so">/so</a>
 
 </td>
 
 <td valign="top" >
-[/sql](http://blekko.com/ws/+/sql) 
-[/tech](http://blekko.com/ws/+/tech) 
-[/techblogs](http://blekko.com/ws/+/techblogs) 
-[/ubuntu](http://blekko.com/ws/+/ubuntu) 
-[/unix](http://blekko.com/ws/+/unix) 
-[/utf8](http://blekko.com/ws/+/utf8) 
-[/ux](http://blekko.com/ws/+/ux) 
-[/videogames](http://blekko.com/ws/+/videogames) 
-[/vim](http://blekko.com/ws/+/vim) 
-[/webdesign](http://blekko.com/ws/+/webdesign) 
-[/windows](http://blekko.com/ws/+/windows) 
+<a href="http://blekko.com/ws/+/sql">/sql</a><br/>
+<a href="http://blekko.com/ws/+/tech">/tech</a><br/>
+<a href="http://blekko.com/ws/+/techblogs">/techblogs</a><br/>
+<a href="http://blekko.com/ws/+/ubuntu">/ubuntu</a><br/>
+<a href="http://blekko.com/ws/+/unix">/unix</a><br/>
+<a href="http://blekko.com/ws/+/utf8">/utf8</a><br/>
+<a href="http://blekko.com/ws/+/ux">/ux</a><br/>
+<a href="http://blekko.com/ws/+/videogames">/videogames</a><br/>
+<a href="http://blekko.com/ws/+/vim">/vim</a><br/>
+<a href="http://blekko.com/ws/+/webdesign">/webdesign</a><br/>
+<a href="http://blekko.com/ws/+/windows">/windows</a>
 
 </td>
 </table>

--- a/_posts/2011-05-31-community-promotion-ads.markdown
+++ b/_posts/2011-05-31-community-promotion-ads.markdown
@@ -67,35 +67,17 @@ Here are a few examples:
 <tr >
 
 <td >
-![AskUbuntu](/images/wordpress/askubuntu.com_.png)
+<img src="/images/wordpress/askubuntu.com_.png" alt="AskUbuntu">
 
 </td>
 
 <td >
-**Ask Ubuntu**
+<strong>Ask Ubuntu</strong>
 
 </td>
 
 <td >
-[Community Promotion Ads - 1H 2011](http://meta.askubuntu.com/questions/1089/community-promotion-ads-1h-2011)
-
-</td>
-</tr>
-
-<tr >
-
-<td >
-![WordPress](/images/wordpress/wordpress.stackexchange.com_.png)
-
-</td>
-
-<td >
-**WordPress Answers**
-
-</td>
-
-<td >
-[Community Promotion Ads - 1H 2011](http://meta.wordpress.stackexchange.com/questions/501/community-promotion-ads-1h-2011)
+<a href="http://meta.askubuntu.com/questions/1089/community-promotion-ads-1h-2011">Community Promotion Ads - 1H 2011</a>
 
 </td>
 </tr>
@@ -103,17 +85,35 @@ Here are a few examples:
 <tr >
 
 <td >
-![TeX](/images/wordpress/tex.stackexchange.com_.png)
+<img src="/images/wordpress/wordpress.stackexchange.com_.png" alt="WordPress">
 
 </td>
 
 <td >
-**TeX - LaTeX**
+<strong>WordPress Answers</strong>
 
 </td>
 
 <td >
-[Community Promotion Ads - 1H 2011](http://meta.tex.stackexchange.com/questions/1184/community-promotion-ads-1h-2011)
+<a href="http://meta.wordpress.stackexchange.com/questions/501/community-promotion-ads-1h-2011">Community Promotion Ads - 1H 2011</a>
+
+</td>
+</tr>
+
+<tr >
+
+<td >
+<img src="/images/wordpress/tex.stackexchange.com_.png" alt="TeX">
+
+</td>
+
+<td >
+<strong>TeX - LaTeX</strong>
+
+</td>
+
+<td >
+<a href="http://meta.tex.stackexchange.com/questions/1184/community-promotion-ads-1h-2011">Community Promotion Ads - 1H 2011</a>
 </td>
 </tr>
 

--- a/_posts/2011-07-16-mobile-stack-exchange.markdown
+++ b/_posts/2011-07-16-mobile-stack-exchange.markdown
@@ -39,10 +39,10 @@ We've had the mobile design in private and public beta for a while to polish up 
 <table >
 <tr >
 
-<td valign="top" >![](/images/wordpress/iphone-mobile-stack-exchange.png)
+<td valign="top" ><img src="/images/wordpress/iphone-mobile-stack-exchange.png">
 </td>
 
-<td valign="top" >![](/images/wordpress/android-mobile-stack-exchange.png)
+<td valign="top" ><img src="/images/wordpress/android-mobile-stack-exchange.png">
 </td>
 </tr>
 </table>

--- a/_posts/2011-08-28-a-bevy-of-new-badges.markdown
+++ b/_posts/2011-08-28-a-bevy-of-new-badges.markdown
@@ -35,7 +35,7 @@ In fact, we've added a bevy of new badges in the last 6 months or so that we hav
 
 <tr >
 <td >
-![](/images/wordpress/analytical-badge.png)
+<img src="/images/wordpress/analytical-badge.png">
 
 </td>
 <td >
@@ -45,7 +45,7 @@ Visited every section of the FAQ
 
 <tr >
 <td >
-![](/images/wordpress/excavator-badge.png)
+<img src="/images/wordpress/excavator-badge.png">
 
 </td>
 <td >
@@ -55,7 +55,7 @@ Edited first post that was inactive for 6 months
 
 <tr >
 <td >
-![](/images/wordpress/archaeologist-badge.png)
+<img src="/images/wordpress/archaeologist-badge.png">
 
 </td>
 <td >
@@ -65,7 +65,7 @@ Edited 100 posts that were inactive for 6 months
 
 <tr >
 <td >
-![](/images/wordpress/deputy-badge.png)
+<img src="/images/wordpress/deputy-badge.png">
 
 </td>
 <td >
@@ -75,7 +75,7 @@ Achieved a flag weight of 500 by reviewing and flagging appropriately
 
 <tr >
 <td >
-![](/images/wordpress/marshal-badge.png)
+<img src="/images/wordpress/marshal-badge.png">
 
 </td>
 <td >
@@ -85,61 +85,61 @@ Achieved a flag weight of 749 by reviewing and flagging appropriately
 
 <tr >
 <td >
-![](/images/wordpress/proofreader-badge.png)
+<img src="/images/wordpress/proofreader-badge.png">
 
 </td>
 <td >
-Approved or rejected 100 [suggested edits](http://blog.stackoverflow.com/2011/02/suggested-edits-and-edit-review/)
+Approved or rejected 100 <a href="http://blog.stackoverflow.com/2011/02/suggested-edits-and-edit-review/">suggested edits</a>
 
 </td></tr>
 
 <tr >
 <td >
-![](/images/wordpress/synonymizer-badge.png)
+<img src="/images/wordpress/synonymizer-badge.png">
 
 </td>
 <td >
-First approved [tag synonym](http://blog.stackoverflow.com/2010/08/tag-folksonomy-and-tag-synonyms/)
+First approved <a href="http://blog.stackoverflow.com/2010/08/tag-folksonomy-and-tag-synonyms/">tag synonym</a>
 
 </td></tr>
 
 <tr >
 <td >
-![](/images/wordpress/tag-editor-badge.png)
+<img src="/images/wordpress/tag-editor-badge.png">
 
 </td>
 <td >
-First [tag wiki edit](http://blog.stackoverflow.com/2010/08/new-tag-info-pages/)
+First <a href="http://blog.stackoverflow.com/2010/08/new-tag-info-pages/">tag wiki edit</a>
 
 </td></tr>
 
 <tr >
 <td >
-![](/images/wordpress/vox-populi-badge.png)
+<img src="/images/wordpress/vox-populi-badge.png">
 
 </td>
 <td >
-Used the maximum [40 votes in a day](http://blog.stackoverflow.com/2011/05/vote-for-this-question-or-the-kitten-gets-it/)
+Used the maximum <a href="http://blog.stackoverflow.com/2011/05/vote-for-this-question-or-the-kitten-gets-it/">40 votes in a day</a>
 
 </td></tr>
 
 <tr >
 <td >
-![](/images/wordpress/quorum-badge.png)
+<img src="/images/wordpress/quorum-badge.png">
 
 </td>
 <td >
-One post with score of 2 [on meta](http://blog.stackoverflow.com/2010/07/new-per-site-metas/)
+One post with score of 2 <a href="http://blog.stackoverflow.com/2010/07/new-per-site-metas/">on meta</a>
 
 </td></tr>
 
 <tr >
 <td >
-![](/images/wordpress/convention-badge.png)
+<img src="/images/wordpress/convention-badge.png">
 
 </td>
 <td >
-10 posts with score of 2 [on meta](http://blog.stackoverflow.com/2010/07/new-per-site-metas/)
+10 posts with score of 2 <a href="http://blog.stackoverflow.com/2010/07/new-per-site-metas/">on meta</a>
 
 </td></tr>
 

--- a/_posts/2011-09-30-stack-exchange-api-usage-stats-and-api-2-0-plans.markdown
+++ b/_posts/2011-09-30-stack-exchange-api-usage-stats-and-api-2-0-plans.markdown
@@ -84,37 +84,37 @@ The top applications by API usage are:
 <td >
 <table width="260" >
 <tr >
-<td >[StackApplet](http://stackapps.com/questions/83/stackapplet-bringing-stack-exchange-notifications-to-your-desktop-1-5-beta-2-r)
+<td ><a href="http://stackapps.com/questions/83/stackapplet-bringing-stack-exchange-notifications-to-your-desktop-1-5-beta-2-r">StackApplet</a>
 <td align="right" >5.3m</tr>
 <tr >
-<td >[Newt](http://stackapps.com/questions/1993/newt-question-answer-and-comment-and-rep-change-notifications-for-os-x)
+<td ><a href="http://stackapps.com/questions/1993/newt-question-answer-and-comment-and-rep-change-notifications-for-os-x">Newt</a>
 <td align="right" >5.2m</tr>
 <tr >
-<td >[Stack Exchange Notifier](http://stackapps.com/questions/1592/stack-exchange-notifier-chrome-extension)
+<td ><a href="http://stackapps.com/questions/1592/stack-exchange-notifier-chrome-extension">Stack Exchange Notifier</a>
 <td align="right" >3.5m</tr>
 <tr >
-<td >[StackGuru](http://stackapps.com/questions/345/stackguru-a-near-realtime-bot-for-all-stackexchange-sites)
+<td ><a href="http://stackapps.com/questions/345/stackguru-a-near-realtime-bot-for-all-stackexchange-sites">StackGuru</a>
 <td align="right" >1.4m</tr>
 <tr >
-<td >[Question Monitor](http://stackapps.com/questions/493/stackstalker-be-notified-when-your-question-is-updated-chrome-extension)
+<td ><a href="http://stackapps.com/questions/493/stackstalker-be-notified-when-your-question-is-updated-chrome-extension">Question Monitor</a>
 <td align="right" >1.3m</tr>
 <tr >
-<td >[Stack Overflow Chat](http://chat.stackoverflow.com)
+<td ><a href="http://chat.stackoverflow.com">Stack Overflow Chat</a>
 <td align="right" >1.1m</tr>
 <tr >
-<td >[New Q!](http://stackapps.com/questions/587/new-q-google-chrome-extension-notifies-you-of-new-questions-of-interest)
+<td ><a href="http://stackapps.com/questions/587/new-q-google-chrome-extension-notifies-you-of-new-questions-of-interest">New Q!</a>
 <td align="right" >943k</tr>
 <tr >
-<td >[VSCommands Lite](http://stackapps.com/questions/1696/stackoverflow-notifications-in-visual-studio-2010-extension)
+<td ><a href="http://stackapps.com/questions/1696/stackoverflow-notifications-in-visual-studio-2010-extension">VSCommands Lite</a>
 <td align="right" >572k</tr>
 <tr >
-<td >[SO Live!](http://stackapps.com/questions/1703/so-live-live-updates-to-your-reputation-score)
+<td ><a href="http://stackapps.com/questions/1703/so-live-live-updates-to-your-reputation-score">SO Live!</a>
 <td align="right" >535k</tr>
 <tr >
-<td >[Droidstack](http://stackapps.com/questions/585/droidstack-for-android-now-with-chat-support)
+<td ><a href="http://stackapps.com/questions/585/droidstack-for-android-now-with-chat-support">Droidstack</a>
 <td align="right" >498k</tr>
 <tr >
-<td >[Coding Clue](http://www.codingclue.com/)
+<td ><a href="http://www.codingclue.com/">Coding Clue</a>
 <td align="right" >473k</tr>
 </table>
 
@@ -123,34 +123,34 @@ The top applications by API usage are:
 <td >
 <table width="260" >
 <tr >
-<td >[StackMobile](http://stackapps.com/questions/36/stackmobile-com-view-stackexchange-sites-on-your-smartphone)
+<td ><a href="http://stackapps.com/questions/36/stackmobile-com-view-stackexchange-sites-on-your-smartphone">StackMobile</a>
 <td align="right" >443k</tr>
 <tr >
-<td >[StackTack](http://stackapps.com/questions/518/stacktack-a-javascript-widget-you-can-stick-anywhere)
+<td ><a href="http://stackapps.com/questions/518/stacktack-a-javascript-widget-you-can-stick-anywhere">StackTack</a>
 <td align="right" >386k</tr>
 <tr >
 <td >StackMonitor
 <td align="right" >356k</tr>
 <tr >
-<td >[StackAnywhere](http://stackapps.com/questions/2370/stackanywhere-a-stack-exchange-client-for-android)
+<td ><a href="http://stackapps.com/questions/2370/stackanywhere-a-stack-exchange-client-for-android">StackAnywhere</a>
 <td align="right" >291k</tr>
 <tr >
-<td >[AskUbuntu Add-on](http://stackapps.com/questions/1699/askubuntu-add-on-for-firefox-opera-and-chrome)
+<td ><a href="http://stackapps.com/questions/1699/askubuntu-add-on-for-firefox-opera-and-chrome">AskUbuntu Add-on</a>
 <td align="right" >251k</tr>
 <tr >
-<td >[stackexchange.com](http://stackexchange.com)
+<td ><a href="http://stackexchange.com">stackexchange.com</a>
 <td align="right" >251k</tr>
 <tr >
-<td >[Swatch for Firefox](http://stackapps.com/questions/316/swatch-a-firefox-plugin-for-monitoring-stack-exchange-sites-for-interesting-chan)
+<td ><a href="http://stackapps.com/questions/316/swatch-a-firefox-plugin-for-monitoring-stack-exchange-sites-for-interesting-chan">Swatch for Firefox</a>
 <td align="right" >185k</tr>
 <tr >
 <td >DFeed IRC bot
 <td align="right" >180k</tr>
 <tr >
-<td >[Area 51](http://area51.stackexchange.com)
+<td ><a href="http://area51.stackexchange.com">Area 51</a>
 <td align="right" >142k</tr>
 <tr >
-<td >[Careers](http://careers.stackoverflow.com)
+<td ><a href="http://careers.stackoverflow.com">Careers</a>
 <td align="right" >140k</tr>
 <tr >
 <td >StackTrends


### PR DESCRIPTION
- Any Markdown inside HTML tags (e.g. inside a `<table>`) isn't
  converted to HTML; this commit replaces a lot of Markdown within
  tables with the appropriate HTML.
- A couple of tweaks to list formatting.
- Fix the formatting of the attribution in a quotation.
- Remove a few phantom (empty) `<table>`s inside the converted Markdown.

---

As with previous PRs, all changes have been built and inspected individually on my machine.
