### PR TITLE
Update links to use their actual locations

### DIFF
--- a/_includes/engineering/sidebar.html
+++ b/_includes/engineering/sidebar.html
@@ -11,7 +11,7 @@
 
 	<section>
 		<p><a href="https://github.com/StackExchange">Open Source</a></p>
-		<p><a href="https://github.com/StackExchange/blog">Blog Repository</a></p>
+		<p><a href="https://github.com/StackExchange/stack-blog">Blog Repository</a></p>
 	</section>
 
 	<section>

--- a/_layouts/company.html
+++ b/_layouts/company.html
@@ -11,12 +11,12 @@ top_nav: company
 <div class="subheader hidden-nav">
 	<div class="inner-container">
 		<nav class="-row">
-			<a class="category{% unless paginator.channel %} active{% endunless %}" href="{{ site.baseurl }}/company">All</a>
-			<a class="category{% if paginator.channel == "announcements" %} active{% endif %}" href="{{ site.baseurl }}/company/announcements">Announcements</a>
-			<a class="category{% if paginator.channel == "podcasts" %} active{% endif %}" href="{{ site.baseurl }}/company/podcasts">Podcasts</a>
-			<a class="category{% if paginator.channel == "community" %} active{% endif %}" href="{{ site.baseurl }}/company/community">Community</a>
-			<a class="category{% if paginator.channel == "culture" %} active{% endif %}" href="{{ site.baseurl }}/company/culture">Culture</a>
-			<a class="category{% if paginator.channel == "diversity" %} active{% endif %}" href="{{ site.baseurl }}/company/diversity">Diversity</a>
+			<a class="category{% unless paginator.channel %} active{% endunless %}" href="{{ site.baseurl }}/company/">All</a>
+			<a class="category{% if paginator.channel == "announcements" %} active{% endif %}" href="{{ site.baseurl }}/company/announcements/">Announcements</a>
+			<a class="category{% if paginator.channel == "podcasts" %} active{% endif %}" href="{{ site.baseurl }}/company/podcasts/">Podcasts</a>
+			<a class="category{% if paginator.channel == "community" %} active{% endif %}" href="{{ site.baseurl }}/company/community/">Community</a>
+			<a class="category{% if paginator.channel == "culture" %} active{% endif %}" href="{{ site.baseurl }}/company/culture/">Culture</a>
+			<a class="category{% if paginator.channel == "diversity" %} active{% endif %}" href="{{ site.baseurl }}/company/diversity/">Diversity</a>
 		</nav>
 	</div>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv='X-UA-Compatible' content='IE=edge'>
     <meta name='viewport' content='width=device-width, initial-scale=1.0'>
-    
+
     <title>{% if page.title %}{{ page.title }} – {% endif %}{{ site.name }} – {{ site.description }}</title>
 
     <meta name="author" content="{{ site.name }}" />
@@ -42,12 +42,12 @@
       <div class="inner-container -row">
         <div class="-col4">
           <a href="{{ site.baseurl }}/" class="site-avatar"><img src="{{ site.avatar }}" /></a>
-        </div>      
+        </div>
         <nav class="-col8 hidden-nav">
           <a class="home{% if page.top_nav == "home" %} active{% endif %}" href="{{ site.baseurl }}/">Home</a>
-          <a class="company{% if page.top_nav == "company" %} active{% endif %}" href="{{ site.baseurl }}/company">Company News</a>
-          <a class="engineering{% if page.top_nav == "engineering" %} active{% endif %}" href="{{ site.baseurl }}/engineering">Engineering</a>
-          <a class="authors{% if page.top_nav == "authors" %} active{% endif %}" href="{{ site.baseurl }}/authors">Contributors</a>
+          <a class="company{% if page.top_nav == "company" %} active{% endif %}" href="{{ site.baseurl }}/company/">Company News</a>
+          <a class="engineering{% if page.top_nav == "engineering" %} active{% endif %}" href="{{ site.baseurl }}/engineering/">Engineering</a>
+          <a class="authors{% if page.top_nav == "authors" %} active{% endif %}" href="{{ site.baseurl }}/authors/">Contributors</a>
         </nav>
       </div>
     </header>

--- a/_layouts/engineering.html
+++ b/_layouts/engineering.html
@@ -11,12 +11,12 @@ top_nav: engineering
 <div class="subheader hidden-nav">
 	<div class="inner-container">
 		<nav class="-row">
-			<a class="category{% unless paginator.channel %} active{% endunless %}" href="{{ site.baseurl}}/engineering">All</a>
-			<a class="category{% if paginator.channel == "development" %} active{% endif %}" href="{{ site.baseurl }}/engineering/development">Development</a>
-			<a class="category{% if paginator.channel == "sysadmin" %} active{% endif %}" href="{{ site.baseurl }}/engineering/sysadmin">Sysadmin</a>
-			<a class="category{% if paginator.channel == "design" %} active{% endif %}" href="{{ site.baseurl }}/engineering/design">Design</a>
-			<a class="category{% if paginator.channel == "evangelism" %} active{% endif %}" href="{{ site.baseurl }}/engineering/evangelism">Evangelism</a>
-			<a class="category{% if paginator.channel == "opinion" %} active{% endif %}" href="{{ site.baseurl }}/engineering/opinion">Opinion</a>
+			<a class="category{% unless paginator.channel %} active{% endunless %}" href="{{ site.baseurl}}/engineering/">All</a>
+			<a class="category{% if paginator.channel == "development" %} active{% endif %}" href="{{ site.baseurl }}/engineering/development/">Development</a>
+			<a class="category{% if paginator.channel == "sysadmin" %} active{% endif %}" href="{{ site.baseurl }}/engineering/sysadmin/">Sysadmin</a>
+			<a class="category{% if paginator.channel == "design" %} active{% endif %}" href="{{ site.baseurl }}/engineering/design/">Design</a>
+			<a class="category{% if paginator.channel == "evangelism" %} active{% endif %}" href="{{ site.baseurl }}/engineering/evangelism/">Evangelism</a>
+			<a class="category{% if paginator.channel == "opinion" %} active{% endif %}" href="{{ site.baseurl }}/engineering/opinion/">Opinion</a>
 		</nav>
 	</div>
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,7 +13,7 @@ layout: default
 	<div class="hero no-image">
 	{% else %}
 	<div class="hero" style="background: linear-gradient(
-      rgba(37, 43, 51, 0.35), 
+      rgba(37, 43, 51, 0.35),
       rgba(37, 43, 51, 0.35)
     ), url('{{ page.hero }}'); background-size: cover;">
 	{% endif %}
@@ -23,7 +23,7 @@ layout: default
 			{% for author in site.authors %}
 			{% if author.id == page.author %}
 				<a href="{{ site.baseurl }}/authors/{{ author.id }}"><img src="{{ author.avatar }}" ></a>
-				<h2 class="h4 author-name">by <a href="{{ site.baseurl }}/authors/{{ author.id }}">{{ author.name }}</a></h2>
+				<h2 class="h4 author-name">by <a href="{{ site.baseurl }}/authors/{{ author.id }}/">{{ author.name }}</a></h2>
 			{% endif %}
 			{% endfor %}
 				<div class="date">on {{ page.date | date: "%B %e, %Y" }}</div>
@@ -43,14 +43,14 @@ layout: default
 				    	<div class="-col6 _textLeft">
 				    	{% for author in site.authors %}
 						{% if author.id == page.author %}
-							<p>By <a href="{{ site.baseurl }}/authors/{{ author.id }}">{{ author.name }}</a>, {{ author.job }}</p>
+							<p>By <a href="{{ site.baseurl }}/authors/{{ author.id }}/">{{ author.name }}</a>, {{ author.job }}</p>
 						{% endif %}
 						{% endfor %}
 					    </div>
 					    <div class="-col6 _textRight">
 					    	<p><strong>Tagged in</strong>&nbsp;
 							{% for tag in page.tags %}
-								<a href="{{ site.baseurl }}/tags/{{ tag }}"><span class="postTag">{{ tag }}</span></a>
+								<a href="{{ site.baseurl }}/tags/{{ tag }}/"><span class="postTag">{{ tag }}</span></a>
 							{% endfor %}</p>
 					    </div>
 				    </div>

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -21,7 +21,7 @@ layout: default
 				<section>
 				<h4>Other Tags</h4>
 				{% for tag in paginator.top_tags %}
-				<p><a href="{{ site.baseurl }}/tags/{{ tag.slug }}"><span class="postTag">{{ tag.name }}</span></a> ({{ tag.count }})</p>
+				<p><a href="{{ site.baseurl }}/tags/{{ tag.slug }}/"><span class="postTag">{{ tag.name }}</span></a> ({{ tag.count }})</p>
 				{% endfor %}
 				</section>
 			</div>

--- a/authors/index.html
+++ b/authors/index.html
@@ -11,9 +11,9 @@ top_nav: authors
 		<div class="authors -row">
 		{% endif %}
 			<div class="author-container large -col6">
-			  	<a href="{{ site.baseurl}}/authors/{{ author.id }}"><img src="{{ author.avatar }}" class="avatar"></a>
+			  	<a href="{{ site.baseurl}}/authors/{{ author.id }}/"><img src="{{ author.avatar }}" class="avatar"></a>
 			  	<div class="info">
-			  		<h2 class="h4 author-name"><a href="{{ site.baseurl}}/authors/{{ author.id }}">{{ author.name }}</a></h2>
+			  		<h2 class="h4 author-name"><a href="{{ site.baseurl}}/authors/{{ author.id }}/">{{ author.name }}</a></h2>
 			  		<h3 class="h5">{{ author.job }}</h3>
 			  		<h3 class="h5 author-info">
 			  			{% if author.twitter %}<a href="https://twitter.com/{{ author.twitter }}">@{{ author.twitter }}</a>{% endif %}

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ pagination: true
 				</section>
 
 				<section>
-				<p><a href="{{ site.baseurl }}/feed">Subscribe via RSS Feed</a></p>
+				<p><a href="{{ site.baseurl }}/feed/">Subscribe via RSS Feed</a></p>
 				</section>
 
 				<section>
@@ -30,16 +30,16 @@ pagination: true
 					<div class="-col6"><h3 class="h6">Tags</h3></div>
 					<div class="-col6"></div>
 				</div>
-				
+
 				{% for tag in paginator.top_tags limit:10 %}
-				<a href="{{ site.baseurl }}/tags/{{ tag.slug }}"><span class="postTag">{{ tag.name }}</span></a>
+				<a href="{{ site.baseurl }}/tags/{{ tag.slug }}/"><span class="postTag">{{ tag.name }}</span></a>
 				{% endfor %}
 				</section>
 
 				<section>
 				<div class="-row">
 					<div class="-col6"><h3 class="h6">Contributors</h3></div>
-					<div class="-col6 _textRight"><p><a href="{{ site.baseurl }}/authors">See all</a></p></div>
+					<div class="-col6 _textRight"><p><a href="{{ site.baseurl }}/authors/">See all</a></p></div>
 				</div>
 				{% include authors.html %}
 				</section>
@@ -49,7 +49,7 @@ pagination: true
 					<div class="-col6"><h3 class="h6">About Us</h3></div>
 					<div class="-col6"></div>
 				</div>
-				
+
 				<p>Welcome! We are <a href="http://stackexchange.com/">Stack Exchange</a>, home of <a href="https://stackoverflow.com/">Stack Overflow</a>, <a href="https://careers.stackoverflow.com/">Stack Overflow Careers</a>, and <a href="http://stackexchange.com/sites">over 100 Q&amp;A sites</a>. In addition to writing a lot of code, we like to write about our coding experiences and other things we’re doing, both at the company and in the tech space as a whole.</p>
 
 				<p>If you’d like to keep up with company initiatives and other happenings at Stack Exchange, check out the Company News channel. If you want to learn about some of our coding projects, mishaps, and other tech details, explore the Engineering channel.</p>


### PR DESCRIPTION
This avoids a redirect, and stops stack exchange's webserver from redirecting down to HTTP.

An alternative to this is to just stop SE's webserver redirecting down to HTTP on a HTTPS request, but I gather information about the protocol used isn't passed over since I'm assuming you use cloudflare.
