### PR TITLE
Feed urls are not valid

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,7 +41,7 @@ google_analytics: ""
 
 # Your website URL (e.g. http://barryclark.github.io or http://www.barryclark.co)
 # Used for Sitemap.xml and your RSS feed
-url: http://stackexchange.github.io/blog
+url: http://blog.stackexchange.com
 
 # Host name for careers-jobs ad server
 adshost: local.clc.stackoverflow.com


### PR DESCRIPTION
Whenever you try to access the blog from a feed the url is not valid (links to http://stackexchange.github.io/blog which is no longer valid).

I updated the url property to correctly map to the current stack exchange blog url.
