### PR TITLE
Search: ensure active page number is readable

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -13,4 +13,8 @@
   .cse .gsc-control-cse, .gsc-control-cse, .cse form.gsc-search-box, form.gsc-search-box {
     padding: 0;
   }
+
+  .gsc-results .gsc-cursor-box .gsc-cursor-current-page {
+      color: #FFFFFF;
+  }
 </style>


### PR DESCRIPTION
This patch changes the active page number text color from grey to white, which makes it more readable on its grey background.

Fixes: http://meta.stackexchange.com/questions/261220/change-foreground-text-color-on-ses-new-blog-search-results-pagination-links

---

This can probably be fixed more cleanly in the GSE configuration, but I don't have access to that (feel free to change it there instead). 
