### PR TITLE
Remove max-widths in layout

### DIFF
--- a/_scss/style.scss
+++ b/_scss/style.scss
@@ -107,8 +107,7 @@ i.blog-icon {
 	}
 }
 .inner-container {
-	max-width: 1000px;
-	margin: 0px auto;
+	margin: 8px;
 	&.padded {
 		margin: 70px auto;
 	}
@@ -252,9 +251,6 @@ article.post {
 	&.draft {
 		background-color: #fff3c7;
 	}
-	.inner-container {
-		max-width: 800px;
-	}
 	.author {
 		font-size: 16px;
 	}
@@ -339,9 +335,6 @@ article.post {
 	}
 	&.full-post {
 		border-bottom: 2px solid #eaeaea;
-		.inner-container {
-			max-width: 700px;
-		}
 		.source {
 			padding: 25px;
 			background: hsla(47, 100%, 89%, 1); 


### PR DESCRIPTION
[Webpages should always be at 100% width.](http://ux.stackexchange.com/q/54117/42756)

It annoys me constantly seeing otherwise responsively-designed websites constrained within a tiny rectangle down the center of the screen, this site being a ridiculous 700px. It's way easier to read at full width.
