### PR TITLE
Add podcast durations

### DIFF
--- a/_posts/2008-04-17-podcast-1.markdown
+++ b/_posts/2008-04-17-podcast-1.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378616-stack-exchange-stack-overflow-podcast-77.mp3
+duration: "00:46:14"
 ---
 
 This is the inaugural episode of the StackOverflow Podcast, with your hosts [Joel Spolsky](http://www.joelonsoftware.com/) and [Jeff Atwood](http://www.codinghorror.com/blog/), wherein we explain what StackOverflow.com will be. We hope.

--- a/_posts/2008-04-23-podcast-2.markdown
+++ b/_posts/2008-04-23-podcast-2.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378610-stack-exchange-stack-overflow-podcast-76.mp3
+duration: "00:50:34"
 ---
 
 

--- a/_posts/2008-04-30-podcast-3.markdown
+++ b/_posts/2008-04-30-podcast-3.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378606-stack-exchange-stack-overflow-podcast-75.mp3
+duration: "01:02:31"
 ---
 
 

--- a/_posts/2008-05-07-podcast-4.markdown
+++ b/_posts/2008-05-07-podcast-4.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378599-stack-exchange-stack-overflow-podcast-74.mp3
+duration: "00:58:46"
 ---
 
 

--- a/_posts/2008-05-14-podcast-5.markdown
+++ b/_posts/2008-05-14-podcast-5.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378587-stack-exchange-stack-overflow-podcast-73.mp3
+duration: "01:05:10"
 ---
 
 

--- a/_posts/2008-05-20-podcast-6.markdown
+++ b/_posts/2008-05-20-podcast-6.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378571-stack-exchange-stack-overflow-podcast-72.mp3
+duration: "01:00:21"
 ---
 
 

--- a/_posts/2008-05-28-podcast-7.markdown
+++ b/_posts/2008-05-28-podcast-7.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378548-stack-exchange-stack-overflow-podcast-71.mp3
+duration: "01:03:48"
 ---
 
 

--- a/_posts/2008-06-04-podcast-8.markdown
+++ b/_posts/2008-06-04-podcast-8.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378533-stack-exchange-stack-overflow-podcast-70.mp3
+duration: "01:06:26"
 ---
 
 

--- a/_posts/2008-06-11-podcast-9.markdown
+++ b/_posts/2008-06-11-podcast-9.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378521-stack-exchange-stack-overflow-podcast-69.mp3
+duration: "01:04:51"
 ---
 
 

--- a/_posts/2008-06-19-podcast-10.markdown
+++ b/_posts/2008-06-19-podcast-10.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378430-stack-exchange-stack-overflow-podcast-67.mp3
+duration: "01:07:39"
 ---
 
 

--- a/_posts/2008-06-26-podcast-11.markdown
+++ b/_posts/2008-06-26-podcast-11.markdown
@@ -13,6 +13,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378417-stack-exchange-stack-overflow-podcast-66.mp3
+duration: "01:07:02"
 ---
 
 

--- a/_posts/2008-07-02-podcast-12.markdown
+++ b/_posts/2008-07-02-podcast-12.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378403-stack-exchange-stack-overflow-podcast-65.mp3
+duration: "01:10:08"
 ---
 
 

--- a/_posts/2008-07-10-podcast-13.markdown
+++ b/_posts/2008-07-10-podcast-13.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378395-stack-exchange-stack-overflow-podcast-64.mp3
+duration: "01:06:55"
 ---
 
 

--- a/_posts/2008-07-16-podcast-14.markdown
+++ b/_posts/2008-07-16-podcast-14.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378386-stack-exchange-stack-overflow-podcast-63.mp3
+duration: "01:11:14"
 ---
 
 

--- a/_posts/2008-07-24-podcast-15.markdown
+++ b/_posts/2008-07-24-podcast-15.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378365-stack-exchange-stack-overflow-podcast-62.mp3
+duration: "01:14:51"
 ---
 
 

--- a/_posts/2008-07-30-podcast-16.markdown
+++ b/_posts/2008-07-30-podcast-16.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378350-stack-exchange-stack-overflow-podcast-61.mp3
+duration: "01:04:49"
 ---
 
 

--- a/_posts/2008-08-13-podcast-17.markdown
+++ b/_posts/2008-08-13-podcast-17.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378336-stack-exchange-stack-overflow-podcast-60.mp3
+duration: "01:01:32"
 ---
 
 

--- a/_posts/2008-08-21-podcast-18.markdown
+++ b/_posts/2008-08-21-podcast-18.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378472-stack-exchange-stack-overflow-podcast-68.mp3
+duration: "01:04:16"
 ---
 
 

--- a/_posts/2008-08-28-podcast-19.markdown
+++ b/_posts/2008-08-28-podcast-19.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378324-stack-exchange-stack-overflow-podcast-59.mp3
+duration: "01:11:15"
 ---
 
 This is the nineteenth episode of the StackOverflow podcast, wherein Joel and I discuss the following:

--- a/_posts/2008-09-03-podcast-20.markdown
+++ b/_posts/2008-09-03-podcast-20.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378285-stack-exchange-stack-overflow-podcast-58.mp3
+duration: "01:05:11"
 ---
 
 This is the twentieth episode of the StackOverflow podcast, wherein Joel and I discuss the following:

--- a/_posts/2008-09-11-podcast-21.markdown
+++ b/_posts/2008-09-11-podcast-21.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378273-stack-exchange-stack-overflow-podcast-57.mp3
+duration: "01:11:00"
 ---
 
 This is the twenty-first episode of the StackOverflow podcast, wherein Joel and I discuss the following:

--- a/_posts/2008-09-18-podcast-22.markdown
+++ b/_posts/2008-09-18-podcast-22.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378270-stack-exchange-stack-overflow-podcast-56.mp3
+duration: "01:06:27"
 ---
 
 This is the twenty-second episode of the StackOverflow podcast, wherein Joel and I discuss the following:

--- a/_posts/2008-09-24-podcast-23.markdown
+++ b/_posts/2008-09-24-podcast-23.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378240-stack-exchange-stack-overflow-podcast-55.mp3
+duration: "01:05:31"
 ---
 
 This is the twenty-third episode of the StackOverflow podcast, wherein Joel and I discuss the following:

--- a/_posts/2008-10-01-podcast-24.markdown
+++ b/_posts/2008-10-01-podcast-24.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378237-stack-exchange-stack-overflow-podcast-54.mp3
+duration: "01:02:38"
 ---
 
 

--- a/_posts/2008-10-09-podcast-25.markdown
+++ b/_posts/2008-10-09-podcast-25.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378231-stack-exchange-stack-overflow-podcast-53.mp3
+duration: "01:15:10"
 ---
 
 

--- a/_posts/2008-10-16-podcast-26.markdown
+++ b/_posts/2008-10-16-podcast-26.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378218-stack-exchange-stack-overflow-podcast-52.mp3
+duration: "00:51:52"
 ---
 
 

--- a/_posts/2008-11-01-podcast-27.markdown
+++ b/_posts/2008-11-01-podcast-27.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378210-stack-exchange-stack-overflow-podcast-51.mp3
+duration: "01:02:30"
 ---
 
 

--- a/_posts/2008-11-06-podcast-28.markdown
+++ b/_posts/2008-11-06-podcast-28.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378204-stack-exchange-stack-overflow-podcast-50.mp3
+duration: "01:09:44"
 ---
 
 

--- a/_posts/2008-11-13-podcast-29.markdown
+++ b/_posts/2008-11-13-podcast-29.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378198-stack-exchange-stack-overflow-podcast-49.mp3
+duration: "01:05:29"
 ---
 
 This is the twenty-ninth episode of the StackOverflow podcast, wherein Joel and I discuss the following:

--- a/_posts/2008-11-20-podcast-30.markdown
+++ b/_posts/2008-11-20-podcast-30.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378109-stack-exchange-stack-overflow-podcast-48.mp3
+duration: "01:01:53"
 ---
 
 

--- a/_posts/2008-11-27-podcast-31.markdown
+++ b/_posts/2008-11-27-podcast-31.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378103-stack-exchange-stack-overflow-podcast-47.mp3
+duration: "01:09:51"
 ---
 
 This is the thirty-first episode of the StackOverflow podcast, where

--- a/_posts/2008-12-04-podcast-32.markdown
+++ b/_posts/2008-12-04-podcast-32.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378083-stack-exchange-stack-overflow-podcast-46.mp3
+duration: "01:11:31"
 ---
 
 

--- a/_posts/2008-12-11-podcast-33.markdown
+++ b/_posts/2008-12-11-podcast-33.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378064-stack-exchange-stack-overflow-podcast-45.mp3
+duration: "01:02:53"
 ---
 
 

--- a/_posts/2008-12-18-podcast-34.markdown
+++ b/_posts/2008-12-18-podcast-34.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378049-stack-exchange-stack-overflow-podcast-44.mp3
+duration: "01:08:41"
 ---
 
 

--- a/_posts/2009-01-01-podcast-35.markdown
+++ b/_posts/2009-01-01-podcast-35.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/220593516-stack-exchange-stack-overflow-podcast-episode-35.mp3
+duration: "01:11:37"
 ---
 
 This is the 35th episode of the StackOverflow podcast, where Joel and Jeff discuss the mysteries of server hardware, anomalous voting patterns, change fatigue, and whether or not Joel is the Martha Stewart of the software industry.

--- a/_posts/2009-01-08-podcast-36.markdown
+++ b/_posts/2009-01-08-podcast-36.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378038-stack-exchange-stack-overflow-podcast-42.mp3
+duration: "01:07:16"
 ---
 
 Joel and Jeff, with special guest Eric Sink of SourceGear, discuss source control present and future, why writing a compiler is an important rite of passage for programmers, and how budding software engineers should be educated.

--- a/_posts/2009-01-15-podcast-37.markdown
+++ b/_posts/2009-01-15-podcast-37.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378030-stack-exchange-stack-overflow-podcast-41.mp3
+duration: "01:05:43"
 ---
 
 This is the 37th episode of the StackOverflow podcast, where Joel and Jeff discuss the expansion of Stack Overflow into non-programming IT topics, the pernicious problem of "systemitis", and how to reach the next generation of programmers.

--- a/_posts/2009-01-22-podcast-38.markdown
+++ b/_posts/2009-01-22-podcast-38.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378022-stack-exchange-stack-overflow-podcast-40.mp3
+duration: "01:08:14"
 ---
 
 This is the 38th episode of the StackOverflow podcast, where Joel and Jeff discuss YSlow optimizations for large websites, the value of unit testing, and the hidden pitfalls of asking questions to programmers.

--- a/_posts/2009-01-30-podcast-39.markdown
+++ b/_posts/2009-01-30-podcast-39.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14378001-stack-exchange-stack-overflow-podcast-39.mp3
+duration: "01:10:10"
 ---
 
 This is the 39th episode of the StackOverflow podcast, where Joel and Jeff discuss database design and the shell game of performance, the value of short, focused presentations, and the importance (or not) of a prestigious degree for software engineers.

--- a/_posts/2009-02-05-podcast-40.markdown
+++ b/_posts/2009-02-05-podcast-40.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377639-stack-exchange-stack-overflow-podcast-38.mp3
+duration: "01:08:52"
 ---
 
 This is the 40th episode of the StackOverflow podcast, where

--- a/_posts/2009-02-12-podcast-41.markdown
+++ b/_posts/2009-02-12-podcast-41.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377610-stack-exchange-stack-overflow-podcast-37.mp3
+duration: "01:05:16"
 ---
 
 This is the 41st episode of the StackOverflow podcast, where Joel and Jeff sit down with [Robert Martin aka "Uncle Bob"](v), and discuss software quality, the value of software engineering principles, and test-driven development.

--- a/_posts/2009-02-19-podcast-42.markdown
+++ b/_posts/2009-02-19-podcast-42.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377607-stack-exchange-stack-overflow-podcast-36.mp3
+duration: "01:11:40"
 ---
 
 

--- a/_posts/2009-02-26-podcast-43.markdown
+++ b/_posts/2009-02-26-podcast-43.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377578-stack-exchange-stack-overflow-podcast-35.mp3
+duration: "01:11:14"
 ---
 
 

--- a/_posts/2009-03-05-podcast-44.markdown
+++ b/_posts/2009-03-05-podcast-44.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377574-stack-exchange-stack-overflow-podcast-34.mp3
+duration: "01:08:57"
 ---
 
 

--- a/_posts/2009-03-12-podcast-45.markdown
+++ b/_posts/2009-03-12-podcast-45.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377551-stack-exchange-stack-overflow-podcast-33.mp3
+duration: "01:13:03"
 ---
 
 This is the 45th episode of the StackOverflow podcast, where Joel and Jeff discuss what a program manager does, the value (or lack thereof) of a functional spec and vision statement, building developer community, and planning your development time.

--- a/_posts/2009-03-20-podcast-46.markdown
+++ b/_posts/2009-03-20-podcast-46.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377508-stack-exchange-stack-overflow-podcast-32.mp3
+duration: "01:09:56"
 ---
 
 

--- a/_posts/2009-03-26-podcast-47.markdown
+++ b/_posts/2009-03-26-podcast-47.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377490-stack-exchange-stack-overflow-podcast-31.mp3
+duration: "01:10:17"
 ---
 
 

--- a/_posts/2009-04-09-podcast-48.markdown
+++ b/_posts/2009-04-09-podcast-48.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377473-stack-exchange-stack-overflow-podcast-30.mp3
+duration: "01:18:44"
 ---
 
 

--- a/_posts/2009-04-15-podcast-49.markdown
+++ b/_posts/2009-04-15-podcast-49.markdown
@@ -13,6 +13,7 @@ tags:
 - background
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377437-stack-exchange-stack-overflow-podcast-29.mp3
+duration: "01:09:16"
 ---
 
 

--- a/_posts/2009-04-23-podcast-50.markdown
+++ b/_posts/2009-04-23-podcast-50.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377371-stack-exchange-stack-overflow-podcast-28.mp3
+duration: "01:17:13"
 ---
 
 

--- a/_posts/2009-04-29-podcast-51.markdown
+++ b/_posts/2009-04-29-podcast-51.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377359-stack-exchange-stack-overflow-podcast-27.mp3
+duration: "00:59:50"
 ---
 
 

--- a/_posts/2009-05-07-podcast-52.markdown
+++ b/_posts/2009-05-07-podcast-52.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377351-stack-exchange-stack-overflow-podcast-26.mp3
+duration: "01:04:42"
 ---
 
 This is the 52nd episode of the StackOverflow podcast -- our one year anniversary -- where Joel and Jeff discuss the launch of Server Fault, how you determine if your code is smelly (or just aromatic), how programmers learn by doing, and how good ideas are often too crazy to copy until it's too late.

--- a/_posts/2009-05-14-podcast-53.markdown
+++ b/_posts/2009-05-14-podcast-53.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377334-stack-exchange-stack-overflow-podcast-25.mp3
+duration: "01:00:25"
 ---
 
 This is the 53rd episode of the StackOverflow podcast where Joel and Jeff sit down with [Wil Shipley](http://www.wilshipley.com/blog/) of [Delicious Monster](http://delicious-monster.com/) to discuss the shifting sands of Apple and Microsoft APIs, the value of software development conferences, intuition versus empiricism for developers, and "parrot programming".

--- a/_posts/2009-05-21-podcast-54.markdown
+++ b/_posts/2009-05-21-podcast-54.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377289-stack-exchange-stack-overflow-podcast-24.mp3
+duration: "01:10:00"
 ---
 
 This is the 54th episode of the StackOverflow podcast where Joel and Jeff discuss bespoke software development, URL routing, the God Algorithm, and getting your database under version control.

--- a/_posts/2009-05-28-podcast-55.markdown
+++ b/_posts/2009-05-28-podcast-55.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377258-stack-exchange-stack-overflow-podcast-23.mp3
+duration: "01:06:36"
 ---
 
 This is the 55th episode of the StackOverflow podcast where Joel and Jeff discuss killer IDEs, how much interview feedback is appropriate (for both parties), and how to teach young programmers who think they know it all.

--- a/_posts/2009-06-04-podcast-56.markdown
+++ b/_posts/2009-06-04-podcast-56.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377248-stack-exchange-stack-overflow-podcast-22.mp3
+duration: "01:15:53"
 ---
 
 This is the 56th episode of the StackOverflow podcast where Joel and Jeff sit down with Jason Calacanis to discuss the business side of software, including Mahalo's "Skee-Ball" economy, when VC funding is appropriate, and whether SEO matters.

--- a/_posts/2009-06-11-podcast-57.markdown
+++ b/_posts/2009-06-11-podcast-57.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377239-stack-exchange-stack-overflow-podcast-21.mp3
+duration: "01:08:35"
 ---
 
 This is the 57th episode of the StackOverflow podcast where Joel and Jeff discuss the relationship between speed and skill, iPhone development, and the value of programming fundamentals.

--- a/_posts/2009-06-18-podcast-58.markdown
+++ b/_posts/2009-06-18-podcast-58.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377208-stack-exchange-stack-overflow-podcast-20.mp3
+duration: "01:04:58"
 ---
 
 This is the 58th episode of the StackOverflow podcast where Joel and Jeff discuss HTML encoding, designing "safe by default", whether a question can be too simple, and the art of beta testing.

--- a/_posts/2009-06-24-podcast-59.markdown
+++ b/_posts/2009-06-24-podcast-59.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377188-stack-exchange-stack-overflow-podcast-19.mp3
+duration: "01:07:15"
 ---
 
 This is the 59th episode of the StackOverflow podcast where Joel and

--- a/_posts/2009-07-02-podcast-60.markdown
+++ b/_posts/2009-07-02-podcast-60.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377094-stack-exchange-stack-overflow-podcast-18.mp3
+duration: "01:08:11"
 ---
 
 This is the 60th episode of the StackOverflow podcast where Joel and Jeff discuss the value (or lack thereof) of meta-discussion, how much "big iron" popular websites need, and whether code forking is sometimes inevitable.

--- a/_posts/2009-07-16-podcast-61.markdown
+++ b/_posts/2009-07-16-podcast-61.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377071-stack-exchange-stack-overflow-podcast-17.mp3
+duration: "01:11:30"
 ---
 
 In this episode of the podcast, Joel and Jeff sit down with [Miguel de Icaza](http://tirania.org/blog/) of the [Mono project](http://mono-project.com/Main_Page) to discuss Mono, Silverlight / Moonlight, and the pros and cons of open sourcing your code.

--- a/_posts/2009-07-23-podcast-62.markdown
+++ b/_posts/2009-07-23-podcast-62.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377051-stack-exchange-stack-overflow-podcast-16.mp3
+duration: "01:04:38"
 ---
 
 

--- a/_posts/2009-07-30-podcast-63.markdown
+++ b/_posts/2009-07-30-podcast-63.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377041-stack-exchange-stack-overflow-podcast-15.mp3
+duration: "01:14:59"
 ---
 
 In this episode of the podcast, Joel and Jeff discuss the Mythical Man Month problem, keeping communication in check, Windows 7, and web scaling.

--- a/_posts/2009-08-06-podcast-64.markdown
+++ b/_posts/2009-08-06-podcast-64.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377032-stack-exchange-stack-overflow-podcast-14.mp3
+duration: "01:06:21"
 ---
 
 Joel and Jeff discuss the disappointment of Google AdSense, the difference in skillset between programmers and testers, and the value of standards groups to working programmers.

--- a/_posts/2009-08-13-podcast-65.markdown
+++ b/_posts/2009-08-13-podcast-65.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14377001-stack-exchange-stack-overflow-podcast-13.mp3
+duration: "01:03:49"
 ---
 
 In this episode of the podcast, Joel and Jeff discuss lessons from a year of building Stack Overflow, the mysteries of COBOL, some YSlow website optimizations, and magic numbers.

--- a/_posts/2009-09-03-podcast-66.markdown
+++ b/_posts/2009-09-03-podcast-66.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14376988-stack-exchange-stack-overflow-podcast-12.mp3
+duration: "01:11:36"
 ---
 
 In this episode of the Stack Overflow podcast, Joel and Jeff discuss reverse proxies, the pitfalls of self-support communities, and designing for engagement.

--- a/_posts/2009-09-10-podcast-67.markdown
+++ b/_posts/2009-09-10-podcast-67.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14376967-stack-exchange-stack-overflow-podcast-11.mp3
+duration: "01:06:13"
 ---
 
 

--- a/_posts/2009-09-18-podcast-68.markdown
+++ b/_posts/2009-09-18-podcast-68.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14376951-stack-exchange-stack-overflow-podcast-10.mp3
+duration: "00:57:58"
 ---
 
 Joel and Jeff discuss outsourced DNS, virtual machine "appliances", and programmers as library users versus library writers.

--- a/_posts/2009-09-30-podcast-69.markdown
+++ b/_posts/2009-09-30-podcast-69.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14376925-stack-exchange-stack-overflow-podcast-9.mp3
+duration: "01:06:59"
 ---
 
 Joel and Jeff sit down with Peter Seibel to discuss his new book [Coders At Work](http://www.amazon.com/dp/1430219483/?tag=codinghorror-20), the effect of listening to music while coding, and the future of programming books.

--- a/_posts/2009-10-15-podcast-70.markdown
+++ b/_posts/2009-10-15-podcast-70.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14376840-stack-exchange-stack-overflow-podcast-7.mp3
+duration: "01:08:02"
 ---
 
 In this episode of the podcast, Joel and Jeff discuss DevDays, the diversity of Stack Exchange sites, the debut of CVs and careers on Stack Overflow, and the viability of WiFi at tech conferences.

--- a/_posts/2009-10-22-podcast-71.markdown
+++ b/_posts/2009-10-22-podcast-71.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14376817-stack-exchange-stack-overflow-podcast-6.mp3
+duration: "01:47:53"
 ---
 
 A collection of clips recorded at the [San Francisco DevDays conference](http://stackoverflow.carsonified.com/events/sanfrancisco/), including Joel Spolsky, Mark Harrison, Jeff Atwood, Scott Hanselman and Rory Blyth. This episode runs a bit longer than usual.

--- a/_posts/2009-10-30-podcast-72.markdown
+++ b/_posts/2009-10-30-podcast-72.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14376799-stack-exchange-stack-overflow-podcast-5.mp3
+duration: "01:17:40"
 ---
 
 Joel and Jeff sit down with Jon Skeet, software engineer at Google London, and the first Stack Overflow user to achieve 100,000 reputation.

--- a/_posts/2009-11-07-podcast-73.markdown
+++ b/_posts/2009-11-07-podcast-73.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14376788-stack-exchange-stack-overflow-podcast-4.mp3
+duration: "01:01:43"
 ---
 
 

--- a/_posts/2009-11-19-podcast-74.markdown
+++ b/_posts/2009-11-19-podcast-74.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14376766-stack-exchange-stack-overflow-podcast-3.mp3
+duration: "01:03:54"
 ---
 
 Joel and Jeff sit down with **[Kathy Sierra](http://en.wikipedia.org/wiki/Kathy_Sierra) and Bert Bates** backstage at the Business of Software 2009 conference.

--- a/_posts/2009-11-24-podcast-75.markdown
+++ b/_posts/2009-11-24-podcast-75.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14376755-stack-exchange-stack-overflow-podcast-2.mp3
+duration: "01:09:47"
 ---
 
 Joel and Jeff sit down with sysadmin extraordinaire Tom Limoncelli of [Everything Sysadmin](http://EverythingSysadmin.com) to discuss IPV6, dumb things for System Administrators to check, and the sysadmin community as reflected in [Server Fault](http://serverfault.com).

--- a/_posts/2009-12-04-podcast-76.markdown
+++ b/_posts/2009-12-04-podcast-76.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14376733-stack-exchange-stack-overflow-podcast-1.mp3
+duration: "00:58:52"
 ---
 
 

--- a/_posts/2009-12-17-podcast-77.markdown
+++ b/_posts/2009-12-17-podcast-77.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14376700-stack-exchange-stack-overflow-podcast.mp3
+duration: "01:08:26"
 ---
 
 

--- a/_posts/2009-12-24-podcast-78.markdown
+++ b/_posts/2009-12-24-podcast-78.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14376662-stack-exchange-stack-overflow-podcast-episode.mp3
+duration: "01:06:28"
 ---
 
 

--- a/_posts/2010-01-10-podcast-79.markdown
+++ b/_posts/2010-01-10-podcast-79.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14376850-stack-exchange-stack-overflow-podcast-8.mp3
+duration: "01:16:26"
 ---
 
 In this episode of the podcast, Joel and Jeff discuss open sourcing Markdown, the necessity of barriers on the open internet, and the importance of design in the software process.

--- a/_posts/2010-01-21-podcast-80.markdown
+++ b/_posts/2010-01-21-podcast-80.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14168976-stack-exchange-stack-exchange-podcast-6.mp3
+duration: "01:06:53"
 ---
 
 In this episode of the Stack Overflow podcast, Joel and Jeff discuss GitHub, the value of formal code documentation, and how to decide what features belong in the next version of your software.

--- a/_posts/2010-02-01-podcast-81.markdown
+++ b/_posts/2010-02-01-podcast-81.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14168893-stack-exchange-stack-exchange-podcast-5.mp3
+duration: "01:10:16"
 ---
 
 In this episode of the Stack Overflow podcast, Joel and Jeff discuss the value of Deep Blue, the Five Whys process, and whether programmers should blog.

--- a/_posts/2010-02-05-podcast-82.markdown
+++ b/_posts/2010-02-05-podcast-82.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14168832-stack-exchange-stack-exchange-podcast-4.mp3
+duration: "01:06:05"
 ---
 
 In this episode of the Stack Overflow podcast, Joel and Jeff sit down with Mac developer Daniel Jalkut of [Red Sweater Software](http://www.red-sweater.com/) to discuss his experience as a longtime Mac developer and small Mac software business owner, and the possible impact of the iPad.

--- a/_posts/2010-02-11-podcast-83.markdown
+++ b/_posts/2010-02-11-podcast-83.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14168813-stack-exchange-stack-exchange-podcast-3.mp3
+duration: "00:52:44"
 ---
 
 In this episode of the Stack Overflow podcast, Joel and Jeff discuss the promise and peril of Email (both social and technical), Google Buzz, and the value of training material.

--- a/_posts/2010-02-20-podcast-84.markdown
+++ b/_posts/2010-02-20-podcast-84.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14168764-stack-exchange-stack-exchange-podcast-2.mp3
+duration: "00:57:59"
 ---
 
 Joel sits down with the Stack Exchange team, who are working on the hosted version of Stack Overflow at the Fog Creek offices in New York City.

--- a/_posts/2010-03-13-podcast-85.markdown
+++ b/_posts/2010-03-13-podcast-85.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14168704-stack-exchange-stack-exchange-podcast.mp3
+duration: "01:01:51"
 ---
 
 In this episode of the Stack Overflow podcast, Joel and Jeff discuss the pursuit of venture capital, why Joel is ending his blog, and the hidden power of Google's web spider.

--- a/_posts/2010-03-24-podcast-86.markdown
+++ b/_posts/2010-03-24-podcast-86.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14105831-stack-exchange-stack-exchange-podcast-episode.mp3
+duration: "00:55:37"
 ---
 
 Joel and Jeff sit down with [Anton Geraschenko](http://mathoverflow.net/users/1/anton-geraschenko) to discuss the unique qualities of a community of expert mathematicians, how to capture a sphere in a knot, and the importance of off-site backups.

--- a/_posts/2010-04-26-podcast-87.markdown
+++ b/_posts/2010-04-26-podcast-87.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14106780-stack-exchange-stack-exchange-podcast-1.mp3
+duration: "01:03:37"
 ---
 
 Joel and Jeff sit down with our new community coordinator, Robert Cartaino, to record a "bonus" podcast discussing the future of Stack Overflow and Stack Exchange 2.0.

--- a/_posts/2011-04-20-podcast-88.markdown
+++ b/_posts/2011-04-20-podcast-88.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/13877633-stack-exchange-se-episode01.mp3
+duration: "01:04:23"
 ---
 
 Welcome back to the first episode of the new Stack Exchange Podcast redux!  Jumping right back into the old groove, here's what happens this week:

--- a/_posts/2011-04-27-se-podcast-02.markdown
+++ b/_posts/2011-04-27-se-podcast-02.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14250494-stack-exchange-se-episode02.mp3
+duration: "01:00:50"
 ---
 
 This week on the Stack Exchange podcast, Jeff and Joel are back into the swing of the weekly podcast and jump right into business, including:

--- a/_posts/2011-05-04-se-podcast-03.markdown
+++ b/_posts/2011-05-04-se-podcast-03.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/14679940-stack-exchange-se-episode03.mp3
+duration: "01:07:46"
 ---
 
 This week, Jeff and Joel are joined by [Scott Hanselman](http://www.hanselman.com/blog/) - tune in for their discussion of everything from MIX11 to the salads at Jack in the Box.

--- a/_posts/2011-05-11-se-podcast-04.markdown
+++ b/_posts/2011-05-11-se-podcast-04.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/15072642-stack-exchange-stack-exchange-podcast-7.mp3
+duration: "01:08:23"
 ---
 
 This week, the Stack Exchange podcast travels to England, where Jeff and Joel are joined by [Stack Overflow legend Jon Skeet](http://blog.stackoverflow.com/2010/09/what-happens-when-you-reach-200k-reputation/) (and son!) along with [Marc Gravell](http://blog.stackoverflow.com/2010/06/welcome-stack-overflow-valued-associates-00006-and-00007/).

--- a/_posts/2011-05-18-se-podcast-05.markdown
+++ b/_posts/2011-05-18-se-podcast-05.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/15494022-stack-exchange-sta.mp3
+duration: "01:02:13"
 ---
 
 The podcast is on the road again this week, with Jeff and Joel coming to you live from Jeff's living room in El Cerrito, CA.  They're also joined by Josh Heyer (aka [Shog9](http://stackoverflow.com/users/811/shog9)) who calls in from Colorado.  This is actually the second time we've done a podcast from Jeff's house, the first time being [Episode #51](http://blog.stackoverflow.com/2009/04/podcast-51/).

--- a/_posts/2011-06-01-se-podcast-06.markdown
+++ b/_posts/2011-06-01-se-podcast-06.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/16327907-stack-exchange-stack-exchange-podcast-8.mp3
+duration: "00:57:58"
 ---
 
 It's our first test of a live podcast!  In case you missed it, we streamed this week's podcast live during the taping. It's something we're playing with and may continue to do in the future if it is popular.  You can tune in to the live tapings Tuesdays @ 4 PM Eastern / 1 PM Pacific -- check Joel and Jeff's Twitter feeds for the location.

--- a/_posts/2011-06-08-se-podcast-07.markdown
+++ b/_posts/2011-06-08-se-podcast-07.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/16777601-stack-exchange-stack-exchange-podcast-9.mp3
+duration: "01:14:02"
 ---
 
 Jeff and Joel are joined by [Sam Saffron](http://stackoverflow.com/users/17174/sam-saffron) (aka [Waffles](http://meta.stackoverflow.com/users/17174/waffles)), our only Australian developer at Stack Exchange!

--- a/_posts/2011-06-16-se-podcast-08.markdown
+++ b/_posts/2011-06-16-se-podcast-08.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/17251043-stack-exchange-se-podcast-08-w-marco-arment.mp3
+duration: "01:04:15"
 ---
 
 This week, Jeff and Joel are joined live "in studio" by [Marco Arment](http://www.marco.org), creator of [Instapaper](http://www.instapaper.com) and formerly the lead developer at Tumblr.  This week's topics include:

--- a/_posts/2011-06-22-se-podcast-09.markdown
+++ b/_posts/2011-06-22-se-podcast-09.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/17651950-stack-exchange-stack-exchange-podcast-10.mp3
+duration: "01:09:10"
 ---
 
 This week, Jeff and Joel are joined by Greg Wilson, an author, developer, and former university professor, who is also an expert on open source software development.  Once make it through the jokes and get his mic sounding great, we can jump in and explore all kinds of interesting topics, like:

--- a/_posts/2011-06-29-se-podcast-10.markdown
+++ b/_posts/2011-06-29-se-podcast-10.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/18077909-stack-exchange-stack-exchange-podcast-11.mp3
+duration: "01:05:39"
 ---
 
 Jeff & Joel are joined by Steve Karantza, better know as [Shirlock Homes](http://diy.stackexchange.com/users/386/shirlock-homes), our #1 user on the [DIY Stack Exchange](http://diy.stackexchange.com/).  Steve is also our first non-programmer oriented guest on the podcast!

--- a/_posts/2011-07-06-se-podcast-11-2.markdown
+++ b/_posts/2011-07-06-se-podcast-11-2.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/18519594-stack-exchange-stack-exchange-podcast-11wrb.mp3
+duration: "01:08:47"
 ---
 
 This week, Jeff and Joel are joined by [Rory Blyth](http://stackoverflow.com/users/183801/rory-blyth) (with no 'e' as he is very insistent) fresh off his move to a new house in Portland, OR.  This week's topics include:

--- a/_posts/2011-07-20-se-podcast-12.markdown
+++ b/_posts/2011-07-20-se-podcast-12.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/19421596-stack-exchange-stack-exchange-podcast-12.mp3
+duration: "00:51:16"
 ---
 
 This week, Jeff and Joel are joined by [Patrick McKenzie](http://www.kalzumeus.com/) - StackOverflow contributor, internet commentator and SEO expert (especially when it comes to driving traffic for [Halloween bingo cards](http://www.halloweenbingocards.net/)).  After a few early tech issues (don't worry, we cleaned up for everyone at home) we jump right into things, with tons of discussion, including:

--- a/_posts/2011-07-27-se-podcast-13.markdown
+++ b/_posts/2011-07-27-se-podcast-13.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/19889804-stack-exchange-stack-exchange-podcast-13.mp3
+duration: "00:59:33"
 ---
 
 Jeff & Joel are joined this week by [Jin Yang](http://www.twitter.com/jzy) - our resident web/graphic designer here at Stack (the distinction between the two becomes a discussion point).  Once we get the proper picture of [Jin](http://www.8164.org/) in the chatroom, he relates everything from his background in design to how he ended up at Stack Exchange and our philosophy behind design.

--- a/_posts/2011-08-03-se-podcast-14.markdown
+++ b/_posts/2011-08-03-se-podcast-14.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/20358142-stack-exchange-stack-exchange-podcast-14.mp3
+duration: "01:07:11"
 ---
 
 [Miguel De Icaza](http://tirania.org/blog/) joins Jeff & Joel this week to discuss everything from Miguel's many projects to identity on the internet to playdates for toddlers.  Miguel is a force in the software world, having initiated and contributed to all kinds of products over the years - he's also well known for being one of the most productive programmers out there.  Check out the full episode for:

--- a/_posts/2011-08-10-se-podcast-15.markdown
+++ b/_posts/2011-08-10-se-podcast-15.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/20873269-stack-exchange-stack-exchange-podcast-15.mp3
+duration: "01:05:53"
 ---
 
 Joining Jeff and Joel this week is [Michael Natkin](http://cooking.stackexchange.com/users/1393/michael-at-herbivoracious), from our Cooking.SE site.  Michael is especially interesting because he is a computer programmer, but he doesn't answer questions at Stack Overflow, only on the Cooking site (he's our first guest to do so!) - he also writes over at [Herbivoracious](http://herbivoracious.com/) (which he started back in 2007).

--- a/_posts/2011-08-31-se-podcast-16.markdown
+++ b/_posts/2011-08-31-se-podcast-16.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/22289079-stack-exchange-stack-exchange-podcast-16.mp3
+duration: "01:11:48"
 ---
 
 So it's been a couple weeks since our last podcast, but Jeff & Joel are back and ready to catch up on everything they missed.  There's no guest this week, just 60+ minutes of that Jeff & Joel banter that (we hope) you've grown to love.

--- a/_posts/2011-09-07-se-podcast-17.markdown
+++ b/_posts/2011-09-07-se-podcast-17.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/22802616-stack-exchange-stack-exchange-podcast-17.mp3
+duration: "01:15:24"
 ---
 
 Jeff & Joel are back with guests this week - joining them are [Kyle Brandt](http://serverfault.com/users/2561/kyle-brandt) and [George Beech](http://serverfault.com/users/5880/zypher), our very own sysadmins/ops guys/[insert your own term here]

--- a/_posts/2011-09-14-se-podcast-18.markdown
+++ b/_posts/2011-09-14-se-podcast-18.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/23329020-stack-exchange-stack-exchange-podcast-18.mp3
+duration: "00:57:41"
 ---
 
 No guest this week as Joel calls in to the show live from the TechCrunch Disrupt Conference in San Francisco since he's there launching [Trello](http://www.trello.com) for Fog Creek Software (also why his audio isn't quite as good as usual, it's pretty loud there).  There's still a full hour of Jeff & Joel goodness though so make sure to check it out!

--- a/_posts/2011-09-21-se-podcast-19.markdown
+++ b/_posts/2011-09-21-se-podcast-19.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/23835379-stack-exchange-stack-exchange-podcast-19.mp3
+duration: "01:07:18"
 ---
 
 Everyone's back in their home towns this week (Sorry for the audio quality last week. It was Joel's fault [actually, it was TechCrunch's fault]). And joining Jeff & Joel this week is [John Sheehan](http://www.twitter.com/johnsheehan), Developer Evangelist for [Twilio](http://www.twilio.com).

--- a/_posts/2011-09-28-se-podcast-20.markdown
+++ b/_posts/2011-09-28-se-podcast-20.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/24342343-stack-exchange-stack-exchange-podcast-20.mp3
+duration: "01:16:39"
 ---
 
 Joining Jeff & Joel this week is [John Siracusa](http://arstechnica.com/author/john-siracusa/), writer for Ars Technica - he's the one who introduced Macs to the Ars world (and apparently ended up converting their entire staff into Mac users).

--- a/_posts/2011-10-05-se-podcast-21.markdown
+++ b/_posts/2011-10-05-se-podcast-21.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/24810127-stack-exchange-stack-exchange-podcast-21.mp3
+duration: "01:05:15"
 ---
 
 This week, Jeff & Joel are joined (in studio, no less) by [David Fullerton](http://stackoverflow.com/users/91687/david-fullerton), head of the NY Dev Department, and [Jason Punyon](http://stackoverflow.com/users/6212/jason-punyon), a developer here in the office.  Its a fast moving discussion covering all kinds of topics, like:

--- a/_posts/2011-10-12-se-podcast-22.markdown
+++ b/_posts/2011-10-12-se-podcast-22.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/25363114-stack-exchange-stack-exchange-podcast-22.mp3
+duration: "00:52:04"
 ---
 
 Joel (but no Jeff) is joined this week by [Paul Biggar](http://paulbiggar.com/research/) (who Joel originally met when he was a DevDays London 2009 speaker about scripting languages).  Paul currently works at Mozilla, having come off his own (not that successful) Y Combinator startup.

--- a/_posts/2011-10-19-se-podcast-23.markdown
+++ b/_posts/2011-10-19-se-podcast-23.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/25906939-stack-exchange-stack-exchange-podcast-23.mp3
+duration: "01:06:29"
 ---
 
 Our guest today is [James Portnow](https://twitter.com/#%21/JamesPortnow) of [Extra Credits](http://www.penny-arcade.com/patv/show/extra-credits). We are also joined in the studio by [David Fullerton](http://meta.stackoverflow.com/users/146719/david-fullerton).

--- a/_posts/2011-10-26-se-podcast-24.markdown
+++ b/_posts/2011-10-26-se-podcast-24.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/26443821-stack-exchange-stack-exchange-podcast-24.mp3
+duration: "01:11:39"
 ---
 
 Jeff & Joel are joined this week by Eric Ries, author and expert on The Lean Startup.  Topics for the chat include:

--- a/_posts/2011-11-02-se-podcast-25-mark-russinovich.markdown
+++ b/_posts/2011-11-02-se-podcast-25-mark-russinovich.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/26994881-stack-exchange-stack-exchange-podcast-25.mp3
+duration: "00:56:34"
 ---
 
 This week's guest is [Mark Russinovich](http://en.wikipedia.org/wiki/Mark_Russinovich), from [SysInternals.com](http://technet.microsoft.com/en-us/sysinternals) and now with Microsoft.

--- a/_posts/2011-11-09-se-podcast-26.markdown
+++ b/_posts/2011-11-09-se-podcast-26.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/27577920-stack-exchange-stack-exchange-podcast-26.mp3
+duration: "00:58:05"
 ---
 
 No guest today. Moot had to postpone his appearance on the show. But David Fullerton is here to hang out with us

--- a/_posts/2011-11-16-se-podcast-27-dave-winer.markdown
+++ b/_posts/2011-11-16-se-podcast-27-dave-winer.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/28160568-stack-exchange-stack-exchange-podcast-27.mp3
+duration: "01:03:34"
 ---
 
 Jeff & Joel are joined today by Dave Winer, who's upset that we don't have a jingle to start the show! He "invented" (well, pioneered, really) the [XML-RPC protocol](http://en.wikipedia.org/wiki/XML-RPC). Dave tells us the story of how and why the protocol came to be.

--- a/_posts/2011-11-23-se-podcast-28-brent-ozar.markdown
+++ b/_posts/2011-11-23-se-podcast-28-brent-ozar.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/28804935-stack-exchange-stack-exchange-podcast-28.mp3
+duration: "00:59:48"
 ---
 
 Jeff & Joel are joined this week by Brent Ozar, database wizard who has helped tons of companies (including Stack) with their massive scaling needs.

--- a/_posts/2011-11-30-se-podcast-29-chris-poole.markdown
+++ b/_posts/2011-11-30-se-podcast-29-chris-poole.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/29369082-stack-exchange-stack-exchange-podcast-29.mp3
+duration: "01:04:01"
 ---
 
 Jeff and Joel are joined today by [Chris "Moot" Poole](http://www.twitter.com/moot), founder of [4chan](http://en.wikipedia.org/wiki/4chan) and [Canv.as](http://www.canv.as).  It's a wide ranging discussion from internet memes and tropes to the danger of the [SOPA bill](http://www.americancensorship.org) that is currently making its way through the house.

--- a/_posts/2011-12-08-se-podcast-30-robert-cartaino-rebecca-chernoff.markdown
+++ b/_posts/2011-12-08-se-podcast-30-robert-cartaino-rebecca-chernoff.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/30073425-stack-exchange-stack-exchange-podcast-30.mp3
+duration: "00:59:47"
 ---
 
 Guests this week are [Robert Cartaino](http://stackexchange.com/users/34933/robert-cartaino?tab=accounts) and [Rebecca Chernoff](http://stackexchange.com/users/60791/rebecca-chernoff?tab=accounts). Yeehaw! They're members of our Community Team.

--- a/_posts/2012-03-01-se-podcast-31-goodbye-jeff.markdown
+++ b/_posts/2012-03-01-se-podcast-31-goodbye-jeff.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/38285361-stack-exchange-stack-exchange-podcast-31.mp3
+duration: "01:06:48"
 ---
 
 Well, it's time for the final Stack Exchange Podcast featuring Jeff Atwood before he [rides off into the sunset](http://blog.stackoverflow.com/2012/02/farewell/).  Tune in to hear Jeff and Joel reminisce about the origins of Stack Exchange, the journey along the way, and listen to some special recordings from those who have been around since the beginning.

--- a/_posts/2012-03-06-se-podcast-32-jarrod-dixon-and-josh-heyer.markdown
+++ b/_posts/2012-03-06-se-podcast-32-jarrod-dixon-and-josh-heyer.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/38889143-stack-exchange-stack-exchange-podcast-32.mp3
+duration: "01:02:54"
 ---
 
 With the recent "REP-OCALYPSE" that happened over the weekend, we thought it was a great time to do another podcast - so come join Joel, Jarrod, and Josh as they talk about some of the recent changes to the site and the motivations behind them.

--- a/_posts/2012-10-15-se-podcast-33-its-back.markdown
+++ b/_posts/2012-10-15-se-podcast-33-its-back.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/63521866-stack-exchange-stack-exchange-podcast-33.mp3
+duration: "00:52:33"
 ---
 
 It's Back! Welcome to episode #33 of the Stack Exchange podcast.  We've got a brand new co-host (Jay Hanlon, our new VP of Community Growth) plus our guest this week is David Fullerton, VP of Engineering at Stack Exchange.

--- a/_posts/2012-10-23-se-podcast-34.markdown
+++ b/_posts/2012-10-23-se-podcast-34.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/64405575-stack-exchange-stack-exchange-podcast-34.mp3
+duration: "00:49:17"
 ---
 
 On the show this week are Kyle Brandt and Nick Craver, two SE employees who are heading up our systems upgrades and relocations - they'll dish all kinds of details on our infrastructure, plus plenty of chat about other mildly relevant things.

--- a/_posts/2012-10-29-se-podcast-35-a-biscuit-away-from-jerry-stiller.markdown
+++ b/_posts/2012-10-29-se-podcast-35-a-biscuit-away-from-jerry-stiller.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/65220816-stack-exchange-stack-exchange-podcast-35.mp3
+duration: "00:50:47"
 ---
 
 Welcome to Stack Exchange podcast #35 with special guest Scott Hanselman. We also have your loyal cohosts, Jay Hanlon and David Fullerton. And Joel Spolsky?

--- a/_posts/2012-11-09-se-podcast-36-we-got-hit-by-a-hurricane.markdown
+++ b/_posts/2012-11-09-se-podcast-36-we-got-hit-by-a-hurricane.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/66762703-stack-exchange-stack-exchange-podcast-36.mp3
+duration: "01:21:40"
 ---
 
 So as you may have heard in the news, the east coast got hit pretty hard by Hurricane Sandy - in particular, our datacenter in Lower Manhattan was almost knocked entirely offline.  If not for the incredible efforts of Fog Creek Software, Squarespace, and Peer1 (the datacenter) there would have certainly been days of outages for everyone involved.

--- a/_posts/2012-11-20-se-podcast-37.markdown
+++ b/_posts/2012-11-20-se-podcast-37.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/68172637-stack-exchange-stack-exchange-podcast-37.mp3
+duration: "00:51:02"
 ---
 
 Welcome back!  We're actually back to a fairly normal podcast this week and want to bring you back up to speed on Stack Exchange after our adventures the last few weeks.  What's on the agenda? What's new this week?

--- a/_posts/2012-12-03-se-podcast-38-this-ones-at-least-a-410.markdown
+++ b/_posts/2012-12-03-se-podcast-38-this-ones-at-least-a-410.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/69812124-stack-exchange-stack-exchange-podcast-38.mp3
+duration: "00:39:07"
 ---
 
 Welcome to Stack Exchange podcast #38 with Joel, Jay, David, and new special guest Will Cole, PM on the Careers team.  We're doing a deep dive into [Careers](http://careers.stackoverflow.com) today, as we have the launch of [Careers in German](http://blog.stackoverflow.com/2012/11/join-stack-overflow-in-berlin-for-a-blowout-bash-on-december-5/) coming up!

--- a/_posts/2012-12-24-podcast-39-the-one-with-wil-wheaton.markdown
+++ b/_posts/2012-12-24-podcast-39-the-one-with-wil-wheaton.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/72432544-stack-exchange-stack-exchange-podcast-39.mp3
+duration: "00:52:52"
 ---
 
 Today's guest is [Jeremy Tunnell](http://stackexchange.com/users/1635441/jeremy-tunnell), who says it's great to be here. He's the new Product Manager on the Stack Exchange team. He works out of Nashville but is in New York with us, recording live in the podcast studio!

--- a/_posts/2013-01-10-podcast-40-2.markdown
+++ b/_posts/2013-01-10-podcast-40-2.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/74385052-stack-exchange-stack-exchange-podcast-40.mp3
+duration: "00:59:29"
 ---
 
 You're listening to the Stack Exchange Podcast #40 (We apologize to everyone who expected Wil Wheaton last week)  Your hosts are David Fullerton, Jay Hanlon, and Joel Spolsky.  We also have a surprise special guest: Britton Payne, professor of Copyright, Trademark, and Emerging Technologies at Fordham University. He knows a lot of things about software patent law, so we grabbed him as he walked by the studio to talk to us.

--- a/_posts/2013-01-28-podcast-41-neither-of-us-have-muscles.markdown
+++ b/_posts/2013-01-28-podcast-41-neither-of-us-have-muscles.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/76831203-stack-exchange-stack-exchange-podcast-41.mp3
+duration: "01:04:04"
 ---
 
 Welcome to Stack Exchange Podcast #41, featuring Joel Spolsky, Jay Hanlon, David Fullerton, Kyle Brandt, Nick Craver, and Geoff Dalgas, with Producer Alex calling in from Denver!  We have a bunch of systems administrators and the like here, because we are in the process of moving datacenters to our new home in New York City.

--- a/_posts/2013-02-05-podcast-42-2.markdown
+++ b/_posts/2013-02-05-podcast-42-2.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/77975208-stack-exchange-stack-exchange-podcast-42.mp3
+duration: "00:54:20"
 ---
 
 Welcome to Stack Exchange Podcast #42 - it's our usual gang back this week with Joel, Jay, David, and Producer Alex.  There's plenty of inside baseball, so put on your rally caps and make sure to stick it through to the end!

--- a/_posts/2013-02-21-podcast-43-false-facts-blood-feuds.markdown
+++ b/_posts/2013-02-21-podcast-43-false-facts-blood-feuds.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/80236224-stack-exchange-stack-exchange-podcast-43.mp3
+duration: "00:59:08"
 ---
 
 Welcome to Stack Exchange Podcast #43 with Joel Spolsky, Jay Hanlon, David Fullerton, and special guest [Alexis Ohanian](http://alexisohanian.com/), calling in from the [Tutorspree](http://www.tutorspree.com/) office. Alexis is the co-founder of [Reddit](http://reddit.com/) and an investor in [Hipmunk](http://hipmunk.com/). He's a strong advocate against SOPA and PIPA, and knows how to dress well while doing so, thanks to Joel. (Listen on to figure out what we're talking about here.)

--- a/_posts/2013-03-06-podcast-44-this-should-have-been-43.markdown
+++ b/_posts/2013-03-06-podcast-44-this-should-have-been-43.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/82092950-stack-exchange-stack-exchange-podcast-44.mp3
+duration: "01:01:59"
 ---
 
 

--- a/_posts/2013-03-18-podcast-45-keeping-it-sharp.markdown
+++ b/_posts/2013-03-18-podcast-45-keeping-it-sharp.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/83835972-stack-exchange-stack-exchange-podcast-45.mp3
+duration: "00:56:15"
 ---
 
 Our guest this week is Eric Lippert - language architect extraordinaire and famous for all his work at Microsoft in developing their languages

--- a/_posts/2013-03-27-podcast-46-the-podcast-that-sounds-dirty-but-isnt.markdown
+++ b/_posts/2013-03-27-podcast-46-the-podcast-that-sounds-dirty-but-isnt.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/85215663-stack-exchange-stack-exchange-podcast-46.mp3
+duration: "00:52:32"
 ---
 
 Our guest this week (after she joins a bit late) is Zuly Gonzalez - Stack Exchange moderator and power user.  As usual, we also have David Fullerton, Jay Hanlon, Joel Spolsky and (Fake) Producer Alex!

--- a/_posts/2013-05-14-podcast-47-do-you-even-twitter-bro.markdown
+++ b/_posts/2013-05-14-podcast-47-do-you-even-twitter-bro.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/92213289-stack-exchange-stack-exchange-podcast-47.mp3
+duration: "00:41:12"
 ---
 
 We're Back!  It's been a while since our last podcast (why you ask - listen to find out!) but we're back now and "stronger" than ever.  It's Joel, David and Jay (plus producer Alex and Abby) coming to you from the brand new SE Podcast Studio (check out the picture below)

--- a/_posts/2013-06-03-podcast-48-sponsored-by-powdermilk-biscuits.markdown
+++ b/_posts/2013-06-03-podcast-48-sponsored-by-powdermilk-biscuits.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/95226481-stack-exchange-stack-exchange-podcast-48.mp3
+duration: "00:52:12"
 ---
 
 Welcome to Stack Exchange Podcast #48! Our guest today is [Jorge Castro](http://jorgecastro.org/), member of the Community Team at [Canonical](http://www.canonical.com/) (of [Ubuntu](http://ubuntu.com/) fame). We also have Robert Cartaino, our very own Director of Community Development, here at Stack Exchange, as well as the usual suspects - David Fullerton, Jay Hanlon, and Joel Spolsky..  Our guest Jorge Castro works **on** Ubuntu, **at** Canonical. He says to pretend it's double Os instead of U's: Ooboontoo. (David, Jay, and Joel work **on** Stack Exchange, **at** Stack Exchange.)

--- a/_posts/2013-06-11-podcast-49-the-one-where-we-edited-out-the-title-reference.markdown
+++ b/_posts/2013-06-11-podcast-49-the-one-where-we-edited-out-the-title-reference.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/96395024-stack-exchange-stack-exchange-podcast-49.mp3
+duration: "00:49:44"
 ---
 
 Welcome to episode 49 of the Stack Exchange Podcast! We are welcoming special guest [Matt Grum](http://photo.stackexchange.com/users/1375/matt-grum), as well as usual suspects Joel, David, and Jay.  Matt is the top rep user on [Photography](http://photography.stackexchange.com/). He's got 957 answers (and has never asked a question)! He's a photographer and a developer, so his exposure to the Photography site came from his involvement with Stack Overflow

--- a/_posts/2013-07-25-podcast-50-listen-to-this-podcast.markdown
+++ b/_posts/2013-07-25-podcast-50-listen-to-this-podcast.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/102518231-stack-exchange-stack-exchange-podcast-50.mp3
+duration: "01:11:36"
 ---
 
 Welcome to Stack Exchange podcast #50, featuring usual suspects Joel Spolsky, Jay Hanlon, and David Fullerton, plus special guest Shog9 aka Nine Shogs [Shogging](http://dictionary.reference.com/browse/shogging).  And remember, today's podcast is sponsored by the House of Lords, bringing you excellent laws, 100% free!

--- a/_posts/2013-08-05-podcast-51-the-return-of-codinghorror.markdown
+++ b/_posts/2013-08-05-podcast-51-the-return-of-codinghorror.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/104100512-stack-exchange-stack-exchange-podcast-51.mp3
+duration: "01:04:01"
 ---
 
 Welcome to Stack Exchange Podcast #51, with special guest [Jeff Atwood](http://www.codinghorror.com/) and the usual suspects Joel Spolsky, David Fullerton, and Jay Hanlon. Today's show was brought to you by [Pan-American World Airways](http://www.panam.org/)!

--- a/_posts/2013-09-03-podcast-52-we-didnt-need-headphones.markdown
+++ b/_posts/2013-09-03-podcast-52-we-didnt-need-headphones.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/108681379-stack-exchange-stack-exchange-podcast-52-we.mp3
+duration: "01:10:46"
 ---
 
 Welcome to Stack Exchange Podcast #52 with your hosts Joel Spolsky, David Fullerton and Jay Hanlon. Today's show is brought to you by Marmite Yeast Extract - you either love it, or hate it! (You probably hate it.) Joining us today are Careers 2.0 Marketing Coordinator Bethany Marzipan, er, Marzewski and Careers 2.0 Product Manager Will Cole.

--- a/_posts/2013-10-28-podcast-53-lets-go-rio.markdown
+++ b/_posts/2013-10-28-podcast-53-lets-go-rio.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/117482173-stack-exchange-stack-exchange-podcast-52.mp3
+duration: "00:49:57"
 ---
 
 Welcome to Stack Exchange Podcast #53 with special guest Gabe Koscky, our new Brazilian community manager, and usual suspects Jay Hanlon, Joel Spolsky, and David Fullerton. Today's show is brought to you by the National Security Administration!

--- a/_posts/2013-11-14-podcast-54-the-one-with-all-the-anachronisms.markdown
+++ b/_posts/2013-11-14-podcast-54-the-one-with-all-the-anachronisms.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/120103057-stack-exchange-stack-exchange-podcast-53.mp3
+duration: "01:08:15"
 ---
 
 Welcome to Stack Exchange Podcast #54, with special guest [Sara J. Chipps](http://sarajchipps.com/)! Joining us today also is CFO Michael Pryor. Your hosts as usual are Jay Hanlon, David Fullerton, and Joel Spolsky. Today's episode is brought to you by [/r/husky](http://reddit.com/r/husky)!

--- a/_posts/2014-02-24-podcast-55-dont-call-it-a-comeback.markdown
+++ b/_posts/2014-02-24-podcast-55-dont-call-it-a-comeback.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/135361168-stack-exchange-stack-exchange-podcast-54.mp3
+duration: "00:59:51"
 ---
 
 Welcome to Stack Exchange Podcast #55, recorded on <del>Friday</del> Thursday the 13th with your hosts Joel Spolsky, David Fullerton, and Jay Hanlon! Today's episode is brought to you by the city of [Sochi, Russia](http://en.wikipedia.org/wiki/Sochi).

--- a/_posts/2014-03-17-podcast-56-green-or-red-curae.markdown
+++ b/_posts/2014-03-17-podcast-56-green-or-red-curae.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/139449126-stack-exchange-stack-exchange-podcast-55.mp3
+duration: "01:00:35"
 ---
 
 Welcome to the Stack Exchange Podcast #56 recorded on Thursday, March 6th 2014, aka the 4th of Adar II 5774, aka the second day of Lent. Today's podcast is sponsored by Patent Trolls of America. Today's guest is Micah Siegel, Senior Patent Advisor at Stack Exchange and Professor Emeritus at Stanford.

--- a/_posts/2014-04-24-podcast-57-we-just-saw-this-on-florp.markdown
+++ b/_posts/2014-04-24-podcast-57-we-just-saw-this-on-florp.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/145239238-stack-exchange-stack-exchange-podcast-episode-57-we-just-saw-this-on-florp.mp3
+duration: "00:46:08"
 ---
 
 Welcome to Stack Exchange Podcast #57, recorded Friday April 11, 2014 with your hosts Jay Hanlon, David Fullerton, and Joel Spolsky. Today's podcast is brought to you by the Heartbleed bug.

--- a/_posts/2014-05-19-podcast-58-pack-em-in-like-bees.markdown
+++ b/_posts/2014-05-19-podcast-58-pack-em-in-like-bees.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/149558524-stack-exchange-stack-exchange-podcast-episode-58-pack-em-in-like-bees.mp3
+duration: "00:59:18"
 ---
 
 Welcome to Stack Exchange Podcast #58 brought to you by [the Stack Exchange iOS app](https://itunes.apple.com/us/app/stack-exchange/id871299723)! Our hosts Joel Spolsky, David Fullerton, and Jay Hanlon are joined this week by our guests, the Stack Exchange Design Team: Jin Yang, Stéphane "The French Guy" Martin, Courtny Cotten, and Josh Hynes.

--- a/_posts/2014-05-29-podcast-59-hes-one-of-those-science-ists.markdown
+++ b/_posts/2014-05-29-podcast-59-hes-one-of-those-science-ists.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/151731070-stack-exchange-stack-exchange-podcast-59-hes-one-of-those-science-ists.mp3
+duration: "01:07:58"
 ---
 
 Welcome to the 59th running of the Stack Exchange podcast, brought to you by Nutella! Your hosts Joel Spolsky, David Fullerton, and Jay Hanlon are joined this week by special guests Josh Heyer (aka Shog9) and Robert Cartaino (aka Robert Cartaino) of the Stack Exchange Community Growth team.

--- a/_posts/2014-07-16-podcast-60-are-we-that-predictable.markdown
+++ b/_posts/2014-07-16-podcast-60-are-we-that-predictable.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/158893545-stack-exchange-stack-exchange-podcast-episode-60-are-we-that-predictable.mp3
+duration: "00:51:31"
 ---
 
 Welcome to Stack Exchange Podcast episode number 60, brought to you by The National Pepperjack Cheese Council. Your hosts today are Joel Spolsky, Jay Hanlon, and David Fullerton (aka Fake Producer Abby).

--- a/_posts/2014-11-25-podcast-61-the-what-jays-done-wrong-podcast.markdown
+++ b/_posts/2014-11-25-podcast-61-the-what-jays-done-wrong-podcast.markdown
@@ -12,6 +12,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/178619053-stack-exchange-stack-exchange-podcast-episode-61-the-what-jays-done-wrong-podcast.mp3
+duration: "00:53:50"
 ---
 
 Welcome to the 61st installment of the Stack Exchange Podcast, brought to you by okra (yes, [that okra](https://en.wikipedia.org/wiki/Okra)). On our show today are David Fullerton, Jay Hanlon, and Joel Spolsky. It's been a _long_ time since we last did a podcast, so let's get started.

--- a/_posts/2015-02-04-podcast-62-delete-this-whole-episode.markdown
+++ b/_posts/2015-02-04-podcast-62-delete-this-whole-episode.markdown
@@ -13,6 +13,7 @@ tags:
 - podcasts
 - announcement
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/189301069-stack-exchange-stack-exchange-podcast-episode-62-delete-this-whole-episode.mp3
+duration: "00:47:33"
 ---
 
 Welcome to Stack Exchange Podcast #62, recorded live on January 20th--with a [live studio audience (kinda)!](http://chat.stackexchange.com/transcript/message/19636047#19636047). Today's podcast was brought to you by the American Venture Capital Association. With you today are our hosts Jay Hanlon, David Fullerton, and Joel Spolsky.

--- a/_posts/2015-03-25-podcast-63-the-plumbers-up-to-67-coins.markdown
+++ b/_posts/2015-03-25-podcast-63-the-plumbers-up-to-67-coins.markdown
@@ -12,6 +12,7 @@ tags:
  - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/197512699-stack-exchange-stack-exchange-podcast-63-the-plumbers-up-to-67-coins.mp3
 wordpress_id: 15379
+duration: "00:51:43"
 ---
 
 Welcome to the Stack Exchange Podcast Episode #63, recorded March 6, 2015 in front of [a live-ish audience](http://chat.stackexchange.com/transcript/512/2015/3/6). Today's podcast is brought to you by Cool Whip by Kraft Foods. A description for this result is not available because of this site's robots.txt -- learn more! Our hosts today are Joel Spolsky, David Fullerton, and Jay Hanlon... as usual.

--- a/_posts/2015-05-11-stack-exchange-podcast-64-diverse-hiring-and-a-cat-named-alan-turing.markdown
+++ b/_posts/2015-05-11-stack-exchange-podcast-64-diverse-hiring-and-a-cat-named-alan-turing.markdown
@@ -13,6 +13,7 @@ tags:
 - diversity
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/204221383-stack-exchange-stack-exchange-podcast-episode-64-not-recorded-in-ithaca.mp3
 wordpress_id: 15818
+duration: "01:05:02"
 ---
 
 Welcome to Stack Exchange Podcast Episode #64, recorded in the podcast studio at Stack Exchange HQ in New York City, NY. 

--- a/_posts/2015-06-16-stack-exchange-podcast-65-the-word-has-two-meanings-you-see.markdown
+++ b/_posts/2015-06-16-stack-exchange-podcast-65-the-word-has-two-meanings-you-see.markdown
@@ -7,6 +7,7 @@ tags:
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/210303965-stack-exchange-stack-exchange-podcast-episode-65-the-word-has-two-meanings-you-see.mp3
 wordpress_id: 15936
+duration: "01:49:14"
 ---
 Welcome to the Stack Exchange Podcast, episode #65, recorded Tuesday, May 12, 2015 at Stack Exchange Headquarters in New York City. Today’s podcast is brought to you by the Association of Airline Mile Programs and hosted by the usual suspects.
 

--- a/_posts/2015-08-03-stack-exchange-podcast-66-thank-you-for-saying-words-to-us.markdown
+++ b/_posts/2015-08-03-stack-exchange-podcast-66-thank-you-for-saying-words-to-us.markdown
@@ -7,6 +7,7 @@ tags:
 - company
 - podcasts
 podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/214902705-stack-exchange-stack-exchange-podcast-66-thank-you-for-saying-words-to-us.mp3
+duration: "01:03:15"
 ---
 
 Welcome to Stack Exchange podcast episode #66, recorded live at Stack Exchange HQ in New York, NY on July 7, 2015. Today's podcast is brought to you by The Association of Ex-Fog Creek Summer Interns (AEFCSI). Today's show is hosted by the usual suspects Jay Hanlon, David Fullerton, and Joel Spolsky, plus ex post facto Producer Alex.

--- a/_posts/2015-08-25-stack-exchange-podcast-67-anil-dash-and-the-firehose-of-nerd-dom.markdown
+++ b/_posts/2015-08-25-stack-exchange-podcast-67-anil-dash-and-the-firehose-of-nerd-dom.markdown
@@ -7,6 +7,7 @@ podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/220
 tags:
 - company
 - podcasts
+duration: "00:51:43"
 ---
 
 Welcome to Stack Exchange podcast episode #67, recorded live from Stack Exchange HQ in NYC on August 11, 2015. Today's podcast is brought to you by [the Stockwell Garage](https://en.wikipedia.org/wiki/Stockwell_Garage), a Grade II* Listed Building since 1988. Joining us on today's podcast are Jay Hanlon, David Fullerton, host Joel Spolsky -- and special guest [Anil Dash](http://twitter.com/anildash) of [Makerbase](https://makerba.se)! (Anil says he's never been invited on the podcast before, but that is [a dirty lie](http://chat.stackexchange.com/transcript/message/23367254#23367254).)

--- a/_posts/2015-09-14-stack-exchange-podcast-68-a-badger-a-horse-and-a-dik-dik-the-documentation-episode.markdown
+++ b/_posts/2015-09-14-stack-exchange-podcast-68-a-badger-a-horse-and-a-dik-dik-the-documentation-episode.markdown
@@ -7,6 +7,7 @@ podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/223
 tags:
 - company
 - podcasts
+duration: "00:55:59"
 ---
 
 Welcome to Stack Exchange Podcast #68 recorded Tuesday, September 1, 2015 at Stack Exchange HQ in New York City. Today's podcast is brought to you by [Labor Day](https://en.wikipedia.org/wiki/Labor_Day) - don't forget to put those [seersucker](https://en.wikipedia.org/wiki/Seersucker) suits away for the season! Your hosts today are David Fullerton, Jay Hanlon, and Joel Spolsky, with special guest [Kevin Montrose](http://stackoverflow.com/users/80572/kevin-montrose).

--- a/feed/podcast/index.xml
+++ b/feed/podcast/index.xml
@@ -79,6 +79,9 @@ Stack Exchange is a fast-growing network of over 100 question and answer sites o
 			<itunes:explicit>no</itunes:explicit>
 			<itunes:summary><![CDATA[{{ post.content | strip_html | unescapeHTML | truncate: 4000 }}]]></itunes:summary>
 			<itunes:subtitle><![CDATA[{{ post.excerpt | strip_html | unescapeHTML | truncate: 255  }}]]></itunes:subtitle>
+			{% if post.duration %}
+                        <itunes:duration>{{ post.duration }}</itunes:duration>
+			{% endif %}
 			<enclosure type="audio/mpeg" url="{{ post.podcast }}" length="0"/>
 		</item>
 		{% endif %}

--- a/podcastDurations.csx
+++ b/podcastDurations.csx
@@ -1,0 +1,34 @@
+using System.Xml.Linq;
+using System.Text.RegularExpressions;
+
+XNamespace itunes = "http://www.itunes.com/dtds/podcast-1.0.dtd";
+
+var soundCloudIds = (
+    from item in XDocument.Load("http://feeds.soundcloud.com/users/soundcloud:users:4273388/sounds.rss").Descendants("item")
+    let guid = item.Element("guid").Value
+    select Tuple.Create(guid.Substring(guid.LastIndexOf('/') + 1), item))
+        .ToLookup(x => x.Item1, x => x.Item2.Element(itunes + "duration").Value);
+var utf8WithoutBom = new System.Text.UTF8Encoding(false);
+
+foreach(var hit in
+    from path in Directory.EnumerateFiles(Path.Combine(Directory.GetCurrentDirectory(), "_posts")).AsParallel()
+    where Regex.Match(path, @"podcast", RegexOptions.IgnoreCase).Success
+    let text = File.ReadAllText(path)
+    let podcast = Regex.Match(text, @"podcast:.*", RegexOptions.IgnoreCase)
+    where podcast.Success
+    let trackId = Regex.Match(podcast.Value, @"stream(/|%2f)(\d+)", RegexOptions.IgnoreCase)
+    where trackId.Success
+    let duration = soundCloudIds[trackId.Groups[2].Value].FirstOrDefault()
+    where duration != null
+    select new { path, duration, text })
+{
+    const string fm = "---";
+    var frontMatterStart = hit.text.IndexOf(fm);
+    var frontMatterEnd = hit.text.IndexOf(fm, frontMatterStart + fm.Length);
+    var frontMatter = hit.text.Substring(fm.Length, frontMatterEnd - fm.Length);
+    if (Regex.Match(frontMatter, @"duration: ", RegexOptions.IgnoreCase).Success) continue;
+
+    frontMatter += "duration: \"" + hit.duration + "\"" + (frontMatter.StartsWith("\r\n") ? "\r\n" : "\n");
+    File.WriteAllText(hit.path, fm + frontMatter + hit.text.Substring(frontMatterEnd), utf8WithoutBom);
+}
+


### PR DESCRIPTION
This is a non-critical but nice-to-have addition to the podcast feed, so listeners can see how long each episode is prior to downloading.

The duration variable would need to be added to the header of new podcast posts, in the format:

<code>duration: "hh:mm:ss"</code>

podcastDurations.csx can backfill missing durations using the SoundCloud feed (based on the existing podcasts.csx).

If adding the duration manually, the official iTunes spec says:

<blockquote>The value provided for this tag can be formatted as HH:MM:SS, H:MM:SS, MM:SS, or M:SS, where H = hours, M = minutes, S = seconds. If a single number is provided as a value (no colons are used), the value is assumed to be in seconds. If one colon is present, the number to the left is assumed to be minutes, and the number to the right is assumed to be seconds. If more than two colons are present, the numbers farthest to the right are ignored.</blockquote>
