### PR TITLE
Fix tag links for tags with a period

### DIFF
--- a/_plugins/StackGen.rb
+++ b/_plugins/StackGen.rb
@@ -83,7 +83,7 @@ module Jekyll
 
     def initialize(name)
       @name = name
-      @slug = name.gsub('.', '-')
+      @slug = name
       @posts = []
     end
 


### PR DESCRIPTION
Fixes [this bug](http://meta.stackexchange.com/questions/264171/se-new-blog-broken-link-on-serverfault-com-and-superuser-com-under-tags) where the tag links to /tags/xyz-abc when the tag is xyz.abc.

I think this makes more sense than making the tag pages use xyz-abc, since it mirrors the name.

The slug variable could probably be removed too, but I figure it makes it obvious that the URL slug is the same as the name.
