### PR TITLE
Use the correct font name for "Helvetica Neue"

### DIFF
--- a/_scss/style.scss
+++ b/_scss/style.scss
@@ -8,7 +8,7 @@ $blue: #0077cc;
 $baseTextGray: rgba(0,0,0,0.8);
 
 html {
-	font-family: 'Helvetica-Nueue', 'Helvetica', sans-serif;
+	font-family: 'Helvetica Neue', 'Helvetica', sans-serif;
 	body {
 		margin: 0;
 		background-color: #fff;


### PR DESCRIPTION
The font name is `'Helvetica Neue'`, and just falls back to Helvetica/sans-serif right now.
