### PR TITLE
Minor copy-editing of a post from 2011

### DIFF
--- a/_posts/2011-09-15-welcome-chaos.markdown
+++ b/_posts/2011-09-15-welcome-chaos.markdown
@@ -58,7 +58,7 @@ Sam  has been on a slow trek eastward for most of his life: starting off in Los
 
 ![](https://i.stack.imgur.com/rTG8F.jpg)
 
-Proving that wasting time on the internet is destructive behavior, Lauren _dropped out of school _to join us at Stack Exchange. If it weren't for us, she would still be pursuing a Ph. D. in Psychology. While in attendance at Duke University, Lauren didn't have access to a car, so she got her motorcycle license and rode around on a hot pink Vespa. In between shifts on the CHAOS squad, Lauren enjoys distance running, traveling, and playing violin - sometimes all at the same time! (To which we say: pics or it didn't happen, Lauren.)
+Proving that wasting time on the internet is destructive behavior, Lauren _dropped out of school_ to join us at Stack Exchange. If it weren't for us, she would still be pursuing a PhD in Psychology. While in attendance at Duke University, Lauren didn't have access to a car, so she got her motorcycle license and rode around on a hot pink Vespa. In between shifts on the CHAOS squad, Lauren enjoys distance running, traveling, and playing violin - sometimes all at the same time! (To which we say: pics or it didn't happen, Lauren.)
 
 **[Katey Healy-Wurzburg](http://stackexchange.com/users/3e019111-ac86-4c6b-a2e7-94d074b235f4)** **(Valued Associate #43):**
 


### PR DESCRIPTION
Typo on line 61 caused some Markdown to not be rendered.

Abbreviations for academic degrees on lines 61 and 77 were inconsistent; the former used both punctuation and spacing and the latter used neither. Of the style references I found, most (including the Chicago Manual of Style and the University of Oxford) preferred PhD to Ph.D. and none allowed spaces within such abbreviations.
