### PR TITLE
Fixed broken penalty-box image

### DIFF
--- a/_posts/2009-04-06-a-day-in-the-penalty-box.markdown
+++ b/_posts/2009-04-06-a-day-in-the-penalty-box.markdown
@@ -93,7 +93,7 @@ So starting tonight, _there will be consequences for patterns of problem behavio
 
 
 
-[![penalty-box](http://blog.stackoverflow.com/wp-content/uploads/penalty-box.jpg)](http://www.flickr.com/photos/jamescalder/511809934/)
+[![penalty-box](https://i.imgur.com/O0asd4N.jpg)](http://www.flickr.com/photos/jamescalder/511809934/)
 
 
 


### PR DESCRIPTION
Fixed broken image, as requested [on meta](http://meta.stackexchange.com/questions/270296/broken-image-in-penalty-box-blog-post).
