### PR TITLE
Fix bad escape of MD-emphasized asterisk

### DIFF
--- a/_posts/2015-08-19-why-stack-overflow-is-a-good-workplace-for-women.md
+++ b/_posts/2015-08-19-why-stack-overflow-is-a-good-workplace-for-women.md
@@ -88,4 +88,4 @@ It's a privilege to work with smart, supportive colleagues every day, and to be 
 
 Oh, and Stack Overflow is [actively hiring](http://stackexchange.com/work-here) :)
 
-*\* Name changed*
+\* *Name changed*


### PR DESCRIPTION
The desired result of `*\* foo*` is to apply MD emphasis to a footnote. The parser apparently gives higher priority to closing emphasis delimiters than to escapes, because the actual result is an italic backslash instead of an escaped asterisk. This PR achieves the desired result by applying MD emphasis only the text of the footnote and not the symbol.
