### PR TITLE
Add a trailing slash to the podcast feed self link to match the actual URL

### DIFF
--- a/feed/podcast/index.xml
+++ b/feed/podcast/index.xml
@@ -17,7 +17,7 @@ redirect_from:
 
 <channel>
 	<title>The Stack Exchange Podcast</title>
-	<atom:link href="{{ site.url }}/feed/podcast" rel="self" type="application/rss+xml" />
+	<atom:link href="{{ site.url }}/feed/podcast/" rel="self" type="application/rss+xml" />
 	<link>{{ site.url }}</link>
 	<description>free, community powered Q&#38;A</description>
 	<lastBuildDate>{{ site.time | date: "%a, %d %b %Y %T +0000" }}</lastBuildDate>


### PR DESCRIPTION
http://blog.stackoverflow.com/feed/podcast is redirected to http://blog.stackoverflow.com/feed/podcast/. However, the `href` of the `<atom:link rel="self">` element in the feed omits the trailing slash  (`http://blog.stackoverflow.com/feed/podcast`). This causes Podcast Addict on Android to fail to load the feed because of a redirect loop.

This pull requests adds a trailing slash to the `href` of the `<atom:link rel="self">` element so that it matches the actual URL of the podcast feed.
