### PR TITLE
Update broken link to GitHub docs

### DIFF
--- a/_posts/2009-10-15-markdown-one-year-later.markdown
+++ b/_posts/2009-10-15-markdown-one-year-later.markdown
@@ -50,7 +50,7 @@ We knew early on that there were [a handful of Markdown Gotchas](http://blog.sta
 
 
 
-Apparently GitHub also uses Markdown, and they independently arrived at some of the same conclusions we did -- synthesizing something they call [GitHub Flavored Markdown](http://github.github.com/github-flavored-markdown/).
+Apparently GitHub also uses Markdown, and they independently arrived at some of the same conclusions we did -- synthesizing something they call [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown).
 
 
 


### PR DESCRIPTION
GitHub is now redirecting the link in question (about Github Flavored Markdown) to a generic help index. I found [a page on Github Guides that specifically addresses GFM](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown). It doesn't have the exact same content but on balance it seems preferable to a [wayback machine link](https://web.archive.org/web/20160123003010/https://help.github.com/articles/github-flavored-markdown/)?

The aforementioned Guides page actually links back to the same URL that's currently broken in this article. I [tweeted at them](https://twitter.com/bakemaster/status/743863856640884736) so perhaps they'll have restored the article by the time this PR is reviewed.
