### PR TITLE
Force google play to recognised updated podcast files

### DIFF
--- a/_posts/2011-07-20-se-podcast-12.markdown
+++ b/_posts/2011-07-20-se-podcast-12.markdown
@@ -11,7 +11,7 @@ wordpress_id: 8771
 tags:
 - company
 - podcasts
-podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/19421596-stack-exchange-stack-exchange-podcast-12.mp3
+podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/19421596-stack-exchange-podcast-12.mp3
 ---
 
 This week, Jeff and Joel are joined by [Patrick McKenzie](http://www.kalzumeus.com/) - StackOverflow contributor, internet commentator and SEO expert (especially when it comes to driving traffic for [Halloween bingo cards](http://www.halloweenbingocards.net/)).  After a few early tech issues (don't worry, we cleaned up for everyone at home) we jump right into things, with tons of discussion, including:

--- a/_posts/2011-07-27-se-podcast-13.markdown
+++ b/_posts/2011-07-27-se-podcast-13.markdown
@@ -11,7 +11,7 @@ wordpress_id: 9033
 tags:
 - company
 - podcasts
-podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/19889804-stack-exchange-stack-exchange-podcast-13.mp3
+podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/19889804-stack-exchange-podcast-13.mp3
 ---
 
 Jeff & Joel are joined this week by [Jin Yang](http://www.twitter.com/jzy) - our resident web/graphic designer here at Stack (the distinction between the two becomes a discussion point).  Once we get the proper picture of [Jin](http://www.8164.org/) in the chatroom, he relates everything from his background in design to how he ended up at Stack Exchange and our philosophy behind design.

--- a/_posts/2011-08-03-se-podcast-14.markdown
+++ b/_posts/2011-08-03-se-podcast-14.markdown
@@ -11,7 +11,7 @@ wordpress_id: 9149
 tags:
 - company
 - podcasts
-podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/20358142-stack-exchange-stack-exchange-podcast-14.mp3
+podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/20358142-stack-exchange-podcast-14.mp3
 ---
 
 [Miguel De Icaza](http://tirania.org/blog/) joins Jeff & Joel this week to discuss everything from Miguel's many projects to identity on the internet to playdates for toddlers.  Miguel is a force in the software world, having initiated and contributed to all kinds of products over the years - he's also well known for being one of the most productive programmers out there.  Check out the full episode for:


### PR DESCRIPTION
This PR should allow google play to pick up the three 'missing' episodes which had invalid (mp2) file formats, now they've been updated to mp3. This required changing the filenames; luckily soundcloud links just ignores everything in the URL after the id. Sneaky! It might affect podtrac analytics? But we can't do anything about that, and they are old episodes. @hairboat 
