### PR TITLE
Changed 'SE podcast' references to 'SO podcast'

### DIFF
--- a/feed/podcast/index.xml
+++ b/feed/podcast/index.xml
@@ -16,7 +16,7 @@ redirect_from:
 >
 
 <channel>
-	<title>The Stack Exchange Podcast</title>
+	<title>The Stack Overflow Podcast</title>
 	<atom:link href="{{ site.url }}/feed/podcast/" rel="self" type="application/rss+xml" />
 	<link>{{ site.url }}</link>
 	<description>free, community powered Q&#38;A</description>
@@ -31,14 +31,14 @@ redirect_from:
 	<ttl>1440</ttl>
 	<image>
 		<url>http://cdn.sstatic.net/stackexchange/img/se-podcast-logo.png</url>
-		<title>The Stack Exchange Podcast</title>
+		<title>The Stack Overflow Podcast</title>
 		<link>{{ site.url }}</link>
 		<width>144</width>
 		<height>144</height>
 	</image>
 	<itunes:new-feed-url>{{ site.url }}/feed/podcast/</itunes:new-feed-url>
 	<itunes:subtitle>A look inside the Stack Exchange Network</itunes:subtitle>
-	<itunes:summary>Hosted by Joel Spolsky with Jay Hanlon and David Fullerton, the Stack Exchange podcast lets you listen in on discussions and decisions about the Stack Exchange Network. The Stack Exchange podcast gives you an unparalleled view into how a startup is created and built.
+	<itunes:summary>Hosted by Joel Spolsky with Jay Hanlon and David Fullerton, the Stack Overflow podcast lets you listen in on discussions and decisions about the Stack Exchange Network. The Stack Overflow podcast gives you an unparalleled view into how a startup is created and built.
 
 About Stack Overflow:
 Stack Overflow is the flagship property of a fast-growing network of over 100 question and answer sites on diverse topics from software programming to cooking to photography and gaming. We are an expert knowledge exchange: a place where physics researchers can ask each other about quantum entanglement, computer programmers can ask about JavaScript date formats, and photographers can share knowledge about taking great pictures in the snow.</itunes:summary>


### PR DESCRIPTION
We finally changed the podcast name!

This PR changes the iTunes and Google Play podcast information to match the new (old!?) podcast name. Both services and any other apps using the feed directly will pick the change up when they next check it, so it will all line up nicely if this goes live with the blog post on the new episode.
@kcpike @hairboat 
