### PR TITLE
Podcast Subscription links.

### DIFF
--- a/_layouts/podcast.html
+++ b/_layouts/podcast.html
@@ -4,4 +4,5 @@ layout: post
 {{content}}
 {% if page.podcast %}
 <p>{{ page.podcast | soundcloudify }}</p>
+<p>Subscribe via <a href="https://itunes.apple.com/us/podcast/the-stack-overflow-podcast/id1033688462?mt=2">iTunes</a> or <a href="https://goo.gl/app/playmusic?ibi=com.google.PlayMusic&isi=691797987&ius=googleplaymusic&link=https://play.google.com/music/m/Ii3bqwtykzjv5hvovej65fv5e2q?t%3DThe_Stack_Overflow_Podcast">Google Play</a>. <a href="{{ page.podcast }}">Download this episode directly.</a></p>
 {% endif %}

--- a/_posts/2008-04-17-podcast-1.markdown
+++ b/_posts/2008-04-17-podcast-1.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-04-17 00:00:16+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/04/podcast-1
 hero: /images/category/podcasts.jpg
 slug: podcast-1
@@ -26,5 +26,5 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W6) for this episode is available for editing. It was graciously submitted by Brian Pelton.
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378616&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+
 

--- a/_posts/2008-04-23-podcast-2.markdown
+++ b/_posts/2008-04-23-podcast-2.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-04-23 00:56:26+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/04/podcast-2
 hero: /images/category/podcasts.jpg
 slug: podcast-2
@@ -50,4 +50,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](http://stackoverflow.fogbugz.com/default.asp?W12) for this episode is available for editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378610&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-04-30-podcast-3.markdown
+++ b/_posts/2008-04-30-podcast-3.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-04-30 00:19:58+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/04/podcast-3
 hero: /images/category/podcasts.jpg
 slug: podcast-3
@@ -74,4 +74,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W56) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378606&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-05-07-podcast-4.markdown
+++ b/_posts/2008-05-07-podcast-4.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-05-07 01:02:06+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/05/podcast-4
 hero: /images/category/podcasts.jpg
 slug: podcast-4
@@ -80,4 +80,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](http://stackoverflow.fogbugz.com/default.asp?W781) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378599&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-05-14-podcast-5.markdown
+++ b/_posts/2008-05-14-podcast-5.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-05-14 03:29:19+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/05/podcast-5
 hero: /images/category/podcasts.jpg
 slug: podcast-5
@@ -77,4 +77,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](http://stackoverflow.fogbugz.com/default.asp?W2434) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378587&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-05-20-podcast-6.markdown
+++ b/_posts/2008-05-20-podcast-6.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-05-20 23:50:19+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/05/podcast-6
 hero: /images/category/podcasts.jpg
 slug: podcast-6
@@ -95,4 +95,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W4331) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378571&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-05-28-podcast-7.markdown
+++ b/_posts/2008-05-28-podcast-7.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-05-28 06:59:32+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/05/podcast-7
 hero: /images/category/podcasts.jpg
 slug: podcast-7
@@ -78,4 +78,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](http://stackoverflow.fogbugz.com/default.asp?W5040) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378548&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-06-04-podcast-8.markdown
+++ b/_posts/2008-06-04-podcast-8.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-06-04 06:59:28+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/06/podcast-8
 hero: /images/category/podcasts.jpg
 slug: podcast-8
@@ -82,4 +82,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](http://stackoverflow.fogbugz.com/default.asp?W6080) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378533&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-06-11-podcast-9.markdown
+++ b/_posts/2008-06-11-podcast-9.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-06-11 23:15:22+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/06/podcast-9
 hero: /images/category/podcasts.jpg
 slug: podcast-9
@@ -135,4 +135,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 The [transcript wiki](http://stackoverflow.fogbugz.com/default.asp?W7782) for this episode is available for public editing.
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378521&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-06-19-podcast-10.markdown
+++ b/_posts/2008-06-19-podcast-10.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-06-19 18:46:18+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/06/podcast-10
 hero: /images/category/podcasts.jpg
 slug: podcast-10
@@ -113,4 +113,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](http://stackoverflow.fogbugz.com/default.asp?W10808) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378430&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-06-26-podcast-11.markdown
+++ b/_posts/2008-06-26-podcast-11.markdown
@@ -5,7 +5,7 @@ date: 2008-06-26 00:41:25+00:00
 excerpt: Joel and Jeff try to avoid talking over each other while discussing data
 redirect_from: /2008/06/podcast-11
 hero: /images/category/podcasts.jpg
-layout: post
+layout: podcast
 slug: podcast-11
 title: 'Podcast #11'
 wordpress_id: 59
@@ -122,4 +122,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W12621) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378417&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-07-02-podcast-12.markdown
+++ b/_posts/2008-07-02-podcast-12.markdown
@@ -4,7 +4,7 @@ comments: true
 date: 2008-07-02 20:50:28+00:00
 redirect_from: /2008/07/podcast-12
 hero: /images/category/podcasts.jpg
-layout: post
+layout: podcast
 slug: podcast-12
 title: 'Podcast #12'
 wordpress_id: 64
@@ -106,4 +106,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](http://stackoverflow.fogbugz.com/default.asp?W12908) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378403&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-07-10-podcast-13.markdown
+++ b/_posts/2008-07-10-podcast-13.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-07-10 03:23:44+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/07/podcast-13
 hero: /images/category/podcasts.jpg
 slug: podcast-13
@@ -106,4 +106,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W13020) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378395&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-07-16-podcast-14.markdown
+++ b/_posts/2008-07-16-podcast-14.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-07-16 22:11:35+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/07/podcast-14
 hero: /images/category/podcasts.jpg
 slug: podcast-14
@@ -84,4 +84,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](http://stackoverflow.fogbugz.com/default.asp?W13086) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378386&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-07-24-podcast-15.markdown
+++ b/_posts/2008-07-24-podcast-15.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-07-24 03:11:58+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/07/podcast-15
 hero: /images/category/podcasts.jpg
 slug: podcast-15
@@ -97,4 +97,4 @@ The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W4) for this
 
 Update: if you had trouble playing back this episode (or the previous one), it may have been due to issues with the way the ID3 tags were stored on the file. The ITConversations folks are on it, and have re-rendered the episodes with a fix.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378365&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-07-30-podcast-16.markdown
+++ b/_posts/2008-07-30-podcast-16.markdown
@@ -4,7 +4,7 @@ comments: true
 date: 2008-07-30 17:54:32+00:00
 redirect_from: /2008/07/podcast-16
 hero: /images/category/podcasts.jpg
-layout: post
+layout: podcast
 slug: podcast-16
 title: 'Podcast #16'
 wordpress_id: 80
@@ -89,4 +89,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](http://stackoverflow.fogbugz.com/default.asp?pg=pgWiki&command=view&ixWikiPage=18721) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378350&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-08-13-podcast-17.markdown
+++ b/_posts/2008-08-13-podcast-17.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-08-13 22:50:14+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/08/podcast-17
 hero: /images/category/podcasts.jpg
 slug: podcast-17
@@ -85,4 +85,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W24212) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378336&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-08-21-podcast-18.markdown
+++ b/_posts/2008-08-21-podcast-18.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-08-21 01:58:39+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/08/podcast-18
 hero: /images/category/podcasts.jpg
 slug: podcast-18
@@ -58,4 +58,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?pg=pgWiki&command=view&ixWikiPage=24213) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378472&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-08-28-podcast-19.markdown
+++ b/_posts/2008-08-28-podcast-19.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-08-28 07:05:11+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/08/podcast-19
 hero: /images/category/podcasts.jpg
 slug: podcast-19
@@ -86,4 +86,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](http://stackoverflow.fogbugz.com/default.asp?W24218) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378324&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-09-03-podcast-20.markdown
+++ b/_posts/2008-09-03-podcast-20.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-09-03 18:48:45+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/09/podcast-20
 hero: /images/category/podcasts.jpg
 slug: podcast-20
@@ -94,4 +94,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?pg=pgWiki&command=view&ixWikiPage=24222) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378285&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-09-11-podcast-21.markdown
+++ b/_posts/2008-09-11-podcast-21.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-09-11 05:04:57+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/09/podcast-21
 hero: /images/category/podcasts.jpg
 slug: podcast-21
@@ -91,4 +91,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W24224) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378273&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-09-18-podcast-22.markdown
+++ b/_posts/2008-09-18-podcast-22.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-09-18 02:05:37+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/09/podcast-22
 hero: /images/category/podcasts.jpg
 slug: podcast-22
@@ -76,4 +76,4 @@ record an audio file (90 seconds or less) and mail it to [podcast@stackoverflow.
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?pg=pgWiki&command=view&ixWikiPage=24227) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378270&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-09-24-podcast-23.markdown
+++ b/_posts/2008-09-24-podcast-23.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-09-24 16:18:30+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/09/podcast-23
 hero: /images/category/podcasts.jpg
 slug: podcast-23
@@ -74,4 +74,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W25450) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378240&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-10-01-podcast-24.markdown
+++ b/_posts/2008-10-01-podcast-24.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-10-01 18:18:17+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/10/podcast-24
 hero: /images/category/podcasts.jpg
 slug: podcast-24
@@ -71,4 +71,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W25778) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378237&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-10-09-podcast-25.markdown
+++ b/_posts/2008-10-09-podcast-25.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-10-09 06:12:32+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/10/podcast-25
 hero: /images/category/podcasts.jpg
 slug: podcast-25
@@ -73,4 +73,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W25795) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378231&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-10-16-podcast-26.markdown
+++ b/_posts/2008-10-16-podcast-26.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-10-16 01:17:08+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/10/podcast-26
 hero: /images/category/podcasts.jpg
 slug: podcast-26
@@ -57,4 +57,4 @@ When calling the audio phone number, be sure to leave your name, so we can prope
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W25802) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378218&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-11-01-podcast-27.markdown
+++ b/_posts/2008-11-01-podcast-27.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-11-01 01:40:22+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/11/podcast-27
 hero: /images/category/podcasts.jpg
 slug: podcast-27
@@ -61,4 +61,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W25965) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378210&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-11-06-podcast-28.markdown
+++ b/_posts/2008-11-06-podcast-28.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-11-06 04:06:57+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/11/podcast-28
 hero: /images/category/podcasts.jpg
 slug: podcast-28
@@ -80,4 +80,4 @@ dedicated phone number you can call to leave audio questions at
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W25972) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378204&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-11-13-podcast-29.markdown
+++ b/_posts/2008-11-13-podcast-29.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-11-13 01:30:07+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/11/podcast-29
 hero: /images/category/podcasts.jpg
 slug: podcast-29
@@ -77,4 +77,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?pg=pgWiki&command=view&ixWikiPage=25973) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378198&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-11-20-podcast-30.markdown
+++ b/_posts/2008-11-20-podcast-30.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-11-20 06:59:36+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/11/podcast-30
 hero: /images/category/podcasts.jpg
 slug: podcast-30
@@ -82,4 +82,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W25975) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378109&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-11-27-podcast-31.markdown
+++ b/_posts/2008-11-27-podcast-31.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-11-27 22:51:21+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/11/podcast-31
 hero: /images/category/podcasts.jpg
 slug: podcast-31
@@ -86,4 +86,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W26423) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378103&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-12-04-podcast-32.markdown
+++ b/_posts/2008-12-04-podcast-32.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-12-04 00:29:09+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/12/podcast-32
 hero: /images/category/podcasts.jpg
 slug: podcast-32
@@ -92,4 +92,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29006) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378083&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-12-11-podcast-33.markdown
+++ b/_posts/2008-12-11-podcast-33.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-12-11 07:24:54+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/12/podcast-33
 hero: /images/category/podcasts.jpg
 slug: podcast-33
@@ -103,4 +103,4 @@ dedicated phone number you can call to leave audio questions at
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29008) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378064&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2008-12-18-podcast-34.markdown
+++ b/_posts/2008-12-18-podcast-34.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2008-12-18 06:26:06+00:00
-layout: post
+layout: podcast
 redirect_from: /2008/12/podcast-34
 hero: /images/category/podcasts.jpg
 slug: podcast-34
@@ -109,4 +109,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?pg=pgWiki&command=view&ixWikiPage=29010) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378049&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-01-01-podcast-35.markdown
+++ b/_posts/2009-01-01-podcast-35.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-01-01 01:23:27+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/01/podcast-35
 hero: /images/category/podcasts.jpg
 slug: podcast-35
@@ -92,5 +92,5 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?pg=pgWiki&command=view&ixWikiPage=29014) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/220593516&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+
 

--- a/_posts/2009-01-08-podcast-36.markdown
+++ b/_posts/2009-01-08-podcast-36.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-01-08 04:49:52+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/01/podcast-36
 hero: /images/category/podcasts.jpg
 slug: podcast-36
@@ -97,4 +97,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?pg=pgWiki&command=view&ixWikiPage=29018) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378038&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-01-15-podcast-37.markdown
+++ b/_posts/2009-01-15-podcast-37.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-01-15 02:34:39+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/01/podcast-37
 hero: /images/category/podcasts.jpg
 slug: podcast-37
@@ -102,4 +102,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29022) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378030&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-01-22-podcast-38.markdown
+++ b/_posts/2009-01-22-podcast-38.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-01-22 03:10:48+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/01/podcast-38
 hero: /images/category/podcasts.jpg
 slug: podcast-38
@@ -116,4 +116,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?pg=pgWiki&command=view&ixWikiPage=29025) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378022&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-01-30-podcast-39.markdown
+++ b/_posts/2009-01-30-podcast-39.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-01-30 05:28:31+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/01/podcast-39
 hero: /images/category/podcasts.jpg
 slug: podcast-39
@@ -105,4 +105,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29026) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14378001&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-02-05-podcast-40.markdown
+++ b/_posts/2009-02-05-podcast-40.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-02-05 06:32:25+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/02/podcast-40
 hero: /images/category/podcasts.jpg
 slug: podcast-40
@@ -112,4 +112,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29028) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377639&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-02-12-podcast-41.markdown
+++ b/_posts/2009-02-12-podcast-41.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-02-12 13:52:12+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/02/podcast-41
 hero: /images/category/podcasts.jpg
 slug: podcast-41
@@ -104,4 +104,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29030) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377610&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-02-19-podcast-42.markdown
+++ b/_posts/2009-02-19-podcast-42.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-02-19 02:37:33+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/02/podcast-42
 hero: /images/category/podcasts.jpg
 slug: podcast-42
@@ -120,4 +120,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29032) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377607&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-02-26-podcast-43.markdown
+++ b/_posts/2009-02-26-podcast-43.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-02-26 02:25:01+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/02/podcast-43
 hero: /images/category/podcasts.jpg
 slug: podcast-43
@@ -109,4 +109,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29033) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377578&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-03-05-podcast-44.markdown
+++ b/_posts/2009-03-05-podcast-44.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-03-05 20:24:45+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/03/podcast-44
 hero: /images/category/podcasts.jpg
 slug: podcast-44
@@ -122,4 +122,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29034) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377574&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-03-12-podcast-45.markdown
+++ b/_posts/2009-03-12-podcast-45.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-03-12 06:59:18+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/03/podcast-45
 hero: /images/category/podcasts.jpg
 slug: podcast-45
@@ -81,4 +81,4 @@ dedicated phone number you can call to leave audio questions at **646-826-3879**
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29035) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377551&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-03-20-podcast-46.markdown
+++ b/_posts/2009-03-20-podcast-46.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-03-20 04:41:52+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/03/podcast-46
 hero: /images/category/podcasts.jpg
 slug: podcast-46
@@ -139,4 +139,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29036) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377508&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-03-26-podcast-47.markdown
+++ b/_posts/2009-03-26-podcast-47.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-03-26 05:00:42+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/03/podcast-47
 hero: /images/category/podcasts.jpg
 slug: podcast-47
@@ -108,4 +108,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29037) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377490&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-04-09-podcast-48.markdown
+++ b/_posts/2009-04-09-podcast-48.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-04-09 04:49:15+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/04/podcast-48
 hero: /images/category/podcasts.jpg
 slug: podcast-48
@@ -88,4 +88,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29040) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377473&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-04-15-podcast-49.markdown
+++ b/_posts/2009-04-15-podcast-49.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-04-15 23:55:45+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/04/podcast-49
 hero: /images/category/podcasts.jpg
 slug: podcast-49
@@ -96,4 +96,4 @@ Reminder: next week, we'll have Steve Yegge as a guest. The [previous episode wi
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?pg=pgWiki&command=view&ixWikiPage=29041) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377437&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-04-23-podcast-50.markdown
+++ b/_posts/2009-04-23-podcast-50.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-04-23 03:14:15+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/04/podcast-50
 hero: /images/category/podcasts.jpg
 slug: podcast-50
@@ -105,4 +105,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29043) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377371&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-04-29-podcast-51.markdown
+++ b/_posts/2009-04-29-podcast-51.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-04-29 21:29:17+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/04/podcast-51
 hero: /images/category/podcasts.jpg
 slug: podcast-51
@@ -107,4 +107,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29044) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377359&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-05-07-podcast-52.markdown
+++ b/_posts/2009-05-07-podcast-52.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-05-07 03:27:43+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/05/podcast-52
 hero: /images/category/podcasts.jpg
 slug: podcast-52
@@ -117,4 +117,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29049) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377351&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-05-14-podcast-53.markdown
+++ b/_posts/2009-05-14-podcast-53.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-05-14 05:37:20+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/05/podcast-53
 hero: /images/category/podcasts.jpg
 slug: podcast-53
@@ -110,4 +110,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29050) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377334&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-05-21-podcast-54.markdown
+++ b/_posts/2009-05-21-podcast-54.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-05-21 18:45:53+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/05/podcast-54
 hero: /images/category/podcasts.jpg
 slug: podcast-54
@@ -110,4 +110,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?pg=pgWiki&command=view&ixWikiPage=29053) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377289&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-05-28-podcast-55.markdown
+++ b/_posts/2009-05-28-podcast-55.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-05-28 14:55:55+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/05/podcast-55
 hero: /images/category/podcasts.jpg
 slug: podcast-55
@@ -112,4 +112,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29056) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377258&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-06-04-podcast-56.markdown
+++ b/_posts/2009-06-04-podcast-56.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-06-04 02:48:51+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/06/podcast-56
 hero: /images/category/podcasts.jpg
 slug: podcast-56
@@ -107,4 +107,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29058) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377248&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-06-11-podcast-57.markdown
+++ b/_posts/2009-06-11-podcast-57.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-06-11 00:51:06+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/06/podcast-57
 hero: /images/category/podcasts.jpg
 slug: podcast-57
@@ -72,4 +72,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29060) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377239&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-06-18-podcast-58.markdown
+++ b/_posts/2009-06-18-podcast-58.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-06-18 02:20:31+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/06/podcast-58
 hero: /images/category/podcasts.jpg
 slug: podcast-58
@@ -98,4 +98,4 @@ using nothing but a telephone and a web browser. We also have a dedicated phone 
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29063) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377208&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-06-24-podcast-59.markdown
+++ b/_posts/2009-06-24-podcast-59.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-06-24 17:18:06+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/06/podcast-59
 hero: https://cloud.githubusercontent.com/assets/12239801/7544303/bc5d6092-f599-11e4-96e6-95ed55104e2c.jpg
 slug: podcast-59
@@ -105,4 +105,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29065) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377188&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-07-02-podcast-60.markdown
+++ b/_posts/2009-07-02-podcast-60.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-07-02 03:14:56+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/07/podcast-60
 hero: /images/category/podcasts.jpg
 slug: podcast-60
@@ -77,4 +77,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29067) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377094&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-07-16-podcast-61.markdown
+++ b/_posts/2009-07-16-podcast-61.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-07-16 00:29:15+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/07/podcast-61
 hero: /images/category/podcasts.jpg
 slug: podcast-61
@@ -99,4 +99,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?pg=pgWiki&ixWikiPage=29068) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377071&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-07-23-podcast-62.markdown
+++ b/_posts/2009-07-23-podcast-62.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-07-23 04:08:53+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/07/podcast-62
 hero: /images/category/podcasts.jpg
 slug: podcast-62
@@ -103,4 +103,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29069) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377051&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-07-30-podcast-63.markdown
+++ b/_posts/2009-07-30-podcast-63.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-07-30 01:29:08+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/07/podcast-63
 hero: /images/category/podcasts.jpg
 slug: podcast-63
@@ -85,4 +85,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29071) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377041&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-08-06-podcast-64.markdown
+++ b/_posts/2009-08-06-podcast-64.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-08-06 04:59:32+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/08/podcast-64
 hero: /images/category/podcasts.jpg
 slug: podcast-64
@@ -82,4 +82,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29074) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377032&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-08-13-podcast-65.markdown
+++ b/_posts/2009-08-13-podcast-65.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-08-13 01:29:05+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/08/podcast-65
 hero: /images/category/podcasts.jpg
 slug: podcast-65
@@ -79,4 +79,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29076) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14377001&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-09-03-podcast-66.markdown
+++ b/_posts/2009-09-03-podcast-66.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-09-03 05:54:11+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/09/podcast-66
 hero: /images/category/podcasts.jpg
 slug: podcast-66
@@ -71,4 +71,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29078) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14376988&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-09-10-podcast-67.markdown
+++ b/_posts/2009-09-10-podcast-67.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-09-10 21:42:47+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/09/podcast-67
 hero: /images/category/podcasts.jpg
 slug: podcast-67
@@ -84,4 +84,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29079) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14376967&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-09-18-podcast-68.markdown
+++ b/_posts/2009-09-18-podcast-68.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-09-18 00:31:44+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/09/podcast-68
 hero: /images/category/podcasts.jpg
 slug: podcast-68
@@ -92,4 +92,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29083) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14376951&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-09-30-podcast-69.markdown
+++ b/_posts/2009-09-30-podcast-69.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-09-30 15:11:40+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/09/podcast-69
 hero: /images/category/podcasts.jpg
 slug: podcast-69
@@ -84,4 +84,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29085) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14376925&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-10-15-podcast-70.markdown
+++ b/_posts/2009-10-15-podcast-70.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-10-15 00:38:14+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/10/podcast-70
 hero: /images/category/podcasts.jpg
 slug: podcast-70
@@ -74,4 +74,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29089) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14376840&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-10-22-podcast-71.markdown
+++ b/_posts/2009-10-22-podcast-71.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-10-22 05:20:17+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/10/podcast-71
 hero: /images/category/podcasts.jpg
 slug: podcast-71
@@ -79,4 +79,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29090) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14376817&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-10-30-podcast-72.markdown
+++ b/_posts/2009-10-30-podcast-72.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-10-30 07:49:00+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/10/podcast-72
 hero: /images/category/podcasts.jpg
 slug: podcast-72
@@ -96,4 +96,4 @@ dedicated phone number you can call to leave audio questions at **646-826-3879**
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29092) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14376799&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-11-07-podcast-73.markdown
+++ b/_posts/2009-11-07-podcast-73.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-11-07 20:24:08+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/11/podcast-73
 hero: /images/category/podcasts.jpg
 slug: podcast-73
@@ -91,4 +91,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29095) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14376788&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-11-19-podcast-74.markdown
+++ b/_posts/2009-11-19-podcast-74.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-11-19 05:08:21+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/11/podcast-74
 hero: /images/category/podcasts.jpg
 slug: podcast-74
@@ -26,4 +26,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29098) for this episode is available for public editing. 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14376766&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-11-24-podcast-75.markdown
+++ b/_posts/2009-11-24-podcast-75.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-11-24 21:22:03+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/11/podcast-75
 hero: /images/category/podcasts.jpg
 slug: podcast-75
@@ -91,4 +91,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29099) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14376755&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-12-04-podcast-76.markdown
+++ b/_posts/2009-12-04-podcast-76.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-12-04 00:14:17+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/12/podcast-76
 hero: /images/category/podcasts.jpg
 slug: podcast-76
@@ -81,4 +81,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29102) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14376733&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-12-17-podcast-77.markdown
+++ b/_posts/2009-12-17-podcast-77.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-12-17 02:28:04+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/12/podcast-77
 hero: /images/category/podcasts.jpg
 slug: podcast-77
@@ -100,4 +100,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29113) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14376700&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2009-12-24-podcast-78.markdown
+++ b/_posts/2009-12-24-podcast-78.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2009-12-24 01:05:32+00:00
-layout: post
+layout: podcast
 redirect_from: /2009/12/podcast-78
 hero: /images/category/podcasts.jpg
 slug: podcast-78
@@ -94,4 +94,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29114) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14376662&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2010-01-10-podcast-79.markdown
+++ b/_posts/2010-01-10-podcast-79.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2010-01-10 04:05:24+00:00
-layout: post
+layout: podcast
 redirect_from: /2010/01/podcast-79
 hero: /images/category/podcasts.jpg
 slug: podcast-79
@@ -68,4 +68,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29119) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14376850&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2010-01-21-podcast-80.markdown
+++ b/_posts/2010-01-21-podcast-80.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2010-01-21 07:38:38+00:00
-layout: post
+layout: podcast
 redirect_from: /2010/01/podcast-80
 hero: /images/category/podcasts.jpg
 slug: podcast-80
@@ -62,4 +62,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29122) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14168976&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2010-02-01-podcast-81.markdown
+++ b/_posts/2010-02-01-podcast-81.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2010-02-01 07:59:39+00:00
-layout: post
+layout: podcast
 redirect_from: /2010/02/podcast-81
 hero: /images/category/podcasts.jpg
 slug: podcast-81
@@ -65,4 +65,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29125) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14168893&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2010-02-05-podcast-82.markdown
+++ b/_posts/2010-02-05-podcast-82.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2010-02-05 23:59:56+00:00
-layout: post
+layout: podcast
 redirect_from: /2010/02/podcast-82
 hero: /images/category/podcasts.jpg
 slug: podcast-82
@@ -77,4 +77,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29126) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14168832&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2010-02-11-podcast-83.markdown
+++ b/_posts/2010-02-11-podcast-83.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2010-02-11 03:58:52+00:00
-layout: post
+layout: podcast
 redirect_from: /2010/02/podcast-83
 hero: /images/category/podcasts.jpg
 slug: podcast-83
@@ -67,4 +67,4 @@ The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29133) for
 
 update: my [2010 webstock talk](http://www.webstock.org.nz/talks/speakers/jeff-atwood/stack-overflow-building-social-software-anti-socia/) is now online.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14168813&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2010-02-20-podcast-84.markdown
+++ b/_posts/2010-02-20-podcast-84.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2010-02-20 07:45:14+00:00
-layout: post
+layout: podcast
 redirect_from: /2010/02/podcast-84
 hero: /images/category/podcasts.jpg
 slug: podcast-84
@@ -53,4 +53,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29177) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14168764&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2010-03-13-podcast-85.markdown
+++ b/_posts/2010-03-13-podcast-85.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2010-03-13 03:38:54+00:00
-layout: post
+layout: podcast
 redirect_from: /2010/03/podcast-85
 hero: /images/category/podcasts.jpg
 slug: podcast-85
@@ -62,4 +62,4 @@ If you'd like to submit a question to be answered in our next episode, record an
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29180) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14168704&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2010-03-24-podcast-86.markdown
+++ b/_posts/2010-03-24-podcast-86.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2010-03-24 05:09:22+00:00
-layout: post
+layout: podcast
 redirect_from: /2010/03/podcast-86
 hero: /images/category/podcasts.jpg
 slug: podcast-86
@@ -54,4 +54,4 @@ Joel and Jeff sit down with [Anton Geraschenko](http://mathoverflow.net/users/1/
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29189) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14105831&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2010-04-26-podcast-87.markdown
+++ b/_posts/2010-04-26-podcast-87.markdown
@@ -2,7 +2,7 @@
 author: jeffatwood
 comments: true
 date: 2010-04-26 21:04:22+00:00
-layout: post
+layout: podcast
 redirect_from: /2010/04/podcast-87
 hero: /images/category/podcasts.jpg
 slug: podcast-87
@@ -53,4 +53,4 @@ We hope you enjoyed this "bonus" podcast. We're still not sure when or if the ne
 
 The [transcript wiki](https://stackoverflow.fogbugz.com/default.asp?W29204) for this episode is available for public editing.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14106780&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2011-04-20-podcast-88.markdown
+++ b/_posts/2011-04-20-podcast-88.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-04-20 15:32:37+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/04/podcast-88
 hero: /images/wordpress/SNAG-0001-300x211.png
 slug: podcast-88
@@ -85,4 +85,4 @@ Also, a big thanks to [Friend of George](http://audio.stackexchange.com/users/12
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/13877633&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2011-04-27-se-podcast-02.markdown
+++ b/_posts/2011-04-27-se-podcast-02.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-04-27 19:00:01+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/04/se-podcast-02
 hero: /images/category/podcasts.jpg
 slug: se-podcast-02
@@ -46,4 +46,3 @@ See you next week when Jeff and Joel are joined by [Scott Hanselman](http://www.
 
 One final note - we're re-numbering the podcast to start back at the beginning, so this is now episode #02 and last week is now episode #01.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14250494&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-05-04-se-podcast-03.markdown
+++ b/_posts/2011-05-04-se-podcast-03.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-05-04 18:00:36+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/05/se-podcast-03
 hero: /images/category/podcasts.jpg
 slug: se-podcast-03
@@ -50,4 +50,4 @@ Tune in to next week's podcast when Joel will be "live" from London and our gues
 
 Also, if you're interested in helping us pick content for Stack Overflow Dev Days - check out [Joel's post on it](http://blog.stackoverflow.com/2011/05/devdays-2011-planning-begins/).
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/14679940&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2011-05-11-se-podcast-04.markdown
+++ b/_posts/2011-05-11-se-podcast-04.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-05-11 17:00:41+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/05/se-podcast-04
 hero: /images/wordpress/photo1.jpg
 slug: se-podcast-04
@@ -70,4 +70,3 @@ Jon needs your help!  If he is chosen to speak at DevDays 2011, what do you  wa
 
 See you next week!
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/15072642&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-05-18-se-podcast-05.markdown
+++ b/_posts/2011-05-18-se-podcast-05.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-05-18 20:52:24+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/05/se-podcast-05
 hero: /images/category/podcasts.jpg
 slug: se-podcast-05
@@ -87,4 +87,4 @@ The podcast is on the road again this week, with Jeff and Joel coming to you liv
 
 There's no podcast next week, but we'll be back the week after, so make sure to join us then!
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/15494022&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2011-06-01-se-podcast-06.markdown
+++ b/_posts/2011-06-01-se-podcast-06.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-06-01 20:40:36+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/06/se-podcast-06
 hero: /images/category/podcasts.jpg
 slug: se-podcast-06
@@ -48,4 +48,3 @@ It's our first test of a live podcast!  In case you missed it, we streamed this
 
 Tune in next week when our guest is [Sam Saffron](http://stackoverflow.com/users/17174/sam-saffron) (aka [Waffles](http://meta.stackoverflow.com/users/17174/waffles)) - once again, you'll be able to watch/listen live on Tuesday @ 4pm as we do the taping.  Follow [@spolsky](https://twitter.com/#!/spolsky) and [@codinghorror](http://www.twitter.com/codinghorror) for the link.  You can also hang out in the [official chat room](http://chat.stackexchange.com/rooms/512/se-podcast-live-chat) during the tapings.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/16327907&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-06-08-se-podcast-07.markdown
+++ b/_posts/2011-06-08-se-podcast-07.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-06-08 23:10:48+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/06/se-podcast-07
 hero: /images/category/podcasts.jpg
 slug: se-podcast-07
@@ -55,4 +55,3 @@ Which Jeff did not pass. :) But the far more interesting test that we're giving 
 
 Join us next week when our guest is [Marco Arment](http://www.marco.org/), the creator of [Instapaper](http://www.instapaper.com/) and the former lead developer of Tumblr.  We'll also be live streaming again, so tune in to [http://www.livestream.com/stackexchange](http://www.livestream.com/stackexchange) starting at 3:30pm - you can also join the live chat at [http://chat.stackexchange.com/rooms/512](http://chat.stackexchange.com/rooms/512).
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/16777601&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-06-16-se-podcast-08.markdown
+++ b/_posts/2011-06-16-se-podcast-08.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-06-16 13:00:40+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/06/se-podcast-08
 hero: /images/category/podcasts.jpg
 slug: se-podcast-08
@@ -114,4 +114,3 @@ This week, Jeff and Joel are joined live "in studio" by [Marco Arment](http://ww
 
 Join us next week, once again live @ 4pm on Tuesday for Greg Wilson for deep insights into the communities surrounding open source software projects.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/17251043&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-06-22-se-podcast-09.markdown
+++ b/_posts/2011-06-22-se-podcast-09.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-06-22 20:27:53+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/06/se-podcast-09
 hero: /images/category/podcasts.jpg
 slug: se-podcast-09
@@ -104,4 +104,3 @@ Even big companies, who have access to the data, have been avoiding actually usi
 
 Thanks for joining us again this week - join us next Tuesday @ 4pm when our guest is Steve Karantza (aka Shirlock Homes on [DIY.StackExchange](http://diy.stackexchange.com/users/386/shirlock-homes)).  We'll be live at [livestream.com/stackexchange](http://www.livestream.com/stackexchange) - see you then!
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/17651950&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-06-29-se-podcast-10.markdown
+++ b/_posts/2011-06-29-se-podcast-10.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-06-29 19:00:21+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/06/se-podcast-10
 hero: /images/category/podcasts.jpg
 slug: se-podcast-10
@@ -75,4 +75,3 @@ Jeff & Joel are joined by Steve Karantza, better know as [Shirlock Homes](http:/
 
 Join us next Tuesday for a special surprise guest!  Not to mention, audio mixing provided by our very own [Jason Punyon](http://stackoverflow.com/users/6212/jason-punyon).
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/18077909&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-07-06-se-podcast-11-2.markdown
+++ b/_posts/2011-07-06-se-podcast-11-2.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-07-06 19:14:41+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/07/se-podcast-11-2
 hero: /images/category/podcasts.jpg
 slug: se-podcast-11-2
@@ -64,4 +64,3 @@ This week, Jeff and Joel are joined by [Rory Blyth](http://stackoverflow.com/use
 
 There's no podcast next week (the 12th) but we'll be back live @ 4pm on the 19th so see you then!
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/18519594&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-07-20-se-podcast-12.markdown
+++ b/_posts/2011-07-20-se-podcast-12.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-07-20 19:00:09+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/07/se-podcast-12
 hero: /images/wordpress/index.png
 slug: se-podcast-12
@@ -73,4 +73,3 @@ This week, Jeff and Joel are joined by [Patrick McKenzie](http://www.kalzumeus.c
 
 We'll see you next week when our guest is [Stack Exchange designer](http://blog.stackoverflow.com/2010/07/our-designer-in-residence-jin-yang/) [Jin Yang](https://twitter.com/#!/jzy)!
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/19421596&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-07-27-se-podcast-13.markdown
+++ b/_posts/2011-07-27-se-podcast-13.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-07-27 19:00:58+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/07/se-podcast-13
 hero: /images/category/podcasts.jpg
 slug: se-podcast-13
@@ -74,4 +74,3 @@ Full topics this week include:
 We'll be back live next week with a bunch of brand new podcast gear  and our special guest: [Miguel De Icaza](http://stackoverflow.com/users/16929/miguel-de-icaza).  Join us for the [live stream](http://www.livestream.com/stackexchange) and in the [official show chatroom](http://chat.stackexchange.com/rooms/512)
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/19889804&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-08-03-se-podcast-14.markdown
+++ b/_posts/2011-08-03-se-podcast-14.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-08-03 19:00:16+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/08/se-podcast-14
 hero: /images/category/podcasts.jpg
 slug: se-podcast-14
@@ -84,4 +84,3 @@ podcast: http://www.podtrac.com/pts/redirect.mp3/feeds.soundcloud.com/stream/203
 
 Join us next week for another live episode on Tuesday @ 4pm (EDT) or catch the posted version on Wednesday.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/20358142&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-08-10-se-podcast-15.markdown
+++ b/_posts/2011-08-10-se-podcast-15.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-08-10 20:00:59+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/08/se-podcast-15
 hero: /images/category/podcasts.jpg
 slug: se-podcast-15
@@ -74,4 +74,3 @@ Their discussion includes:
 
 Thanks for joining us!  We'll be on "summer vacation" for the next couple weeks, but we'll be back on August 30th @ 4pm EDT with [Anita Graser](http://gis.stackexchange.com/users/187/underdark) from [GIS.SE](http://gis.stackexchange.com) (and our first female guest!).
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/20873269&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-08-31-se-podcast-16.markdown
+++ b/_posts/2011-08-31-se-podcast-16.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-08-31 19:00:16+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/08/se-podcast-16
 hero: /images/category/podcasts.jpg
 slug: se-podcast-16
@@ -49,4 +49,3 @@ We're back on our regular schedule now, so tune in next week for another great e
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/22289079&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-09-07-se-podcast-17.markdown
+++ b/_posts/2011-09-07-se-podcast-17.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-09-07 19:00:27+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/09/se-podcast-17
 hero: /images/category/podcasts.jpg
 slug: se-podcast-17
@@ -45,4 +45,3 @@ After a brief test of the emergency broadcast system, we plunge right into the p
 That's it!  Tune in next week at the usual time for another episode with more guests!
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/22802616&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-09-14-se-podcast-18.markdown
+++ b/_posts/2011-09-14-se-podcast-18.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-09-14 19:00:45+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/09/se-podcast-18
 hero: /images/category/podcasts.jpg
 slug: se-podcast-18
@@ -54,4 +54,4 @@ Tune in next week at the normal time and with our normal in-studio setup (really
 See you then!
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/23329020&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2011-09-21-se-podcast-19.markdown
+++ b/_posts/2011-09-21-se-podcast-19.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-09-21 19:00:13+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/09/se-podcast-19
 hero: /images/category/podcasts.jpg
 slug: se-podcast-19
@@ -69,4 +69,3 @@ Everyone's back in their home towns this week (Sorry for the audio quality last 
 
 Join us next week at the normal time when our guest will be John Siracusa from Ars Technica (or as Joel likes to refer to him: "he wrote that really amazing review of Lion").
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/23835379&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-09-28-se-podcast-20.markdown
+++ b/_posts/2011-09-28-se-podcast-20.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-09-28 19:00:07+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/09/se-podcast-20
 hero: /images/category/podcasts.jpg
 slug: se-podcast-20
@@ -59,4 +59,4 @@ Joining Jeff & Joel this week is [John Siracusa](http://arstechnica.com/author/j
 
 Join us next week when Jeff and Joel are joined by David Fullerton, the head of our NY (read: SO Careers) Dev Team.  Same Place, Same Time.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/24342343&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2011-10-05-se-podcast-21.markdown
+++ b/_posts/2011-10-05-se-podcast-21.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-10-05 19:00:11+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/10/se-podcast-21
 hero: /images/category/podcasts.jpg
 slug: se-podcast-21
@@ -60,4 +60,3 @@ This week, Jeff & Joel are joined (in studio, no less) by [David Fullerton](http
 
 Join us next week at the usual time when we'll be joined by [Paul Biggar](http://paulbiggar.com/) and his wonderful Irish accent.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/24810127&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-10-12-se-podcast-22.markdown
+++ b/_posts/2011-10-12-se-podcast-22.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-10-12 19:00:19+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/10/se-podcast-22
 hero: /images/category/podcasts.jpg
 slug: se-podcast-22
@@ -51,4 +51,3 @@ Joel (but no Jeff) is joined this week by [Paul Biggar](http://paulbiggar.com/re
 
 Join us next week when our guest is James Portnow from [Extra Credits](http://www.penny-arcade.com/patv/show/extra-credits) - same place, same time.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/25363114&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-10-19-se-podcast-23.markdown
+++ b/_posts/2011-10-19-se-podcast-23.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-10-19 19:00:36+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/10/se-podcast-23
 hero: /images/category/podcasts.jpg
 slug: se-podcast-23
@@ -63,4 +63,4 @@ Our guest today is [James Portnow](https://twitter.com/#%21/JamesPortnow) of 
 
 Make sure to tune in next week when our guest is Eric Ries.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/25906939&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2011-10-26-se-podcast-24.markdown
+++ b/_posts/2011-10-26-se-podcast-24.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-10-26 19:00:50+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/10/se-podcast-24
 hero: /images/category/podcasts.jpg
 slug: se-podcast-24
@@ -60,4 +60,3 @@ Jeff & Joel are joined this week by Eric Ries, author and expert on The Lean Sta
 
 Make sure to join us next week (at the usual time of course) when our guest is Mar Russinovich.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/26443821&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-11-02-se-podcast-25-mark-russinovich.markdown
+++ b/_posts/2011-11-02-se-podcast-25-mark-russinovich.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-11-02 19:00:15+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/11/se-podcast-25-mark-russinovich
 hero: /images/category/podcasts.jpg
 slug: se-podcast-25-mark-russinovich
@@ -63,4 +63,3 @@ This week's guest is [Mark Russinovich](http://en.wikipedia.org/wiki/Mark_Russin
 
 Next week's guest is [Chris "moot" Poole](http://en.wikipedia.org/wiki/Christopher_Poole), from [4chan](http://www.4chan.org) and [Canvas](http://www.canv.as).
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/26994881&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-11-09-se-podcast-26.markdown
+++ b/_posts/2011-11-09-se-podcast-26.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-11-09 20:00:59+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/11/se-podcast-26
 hero: /images/category/podcasts.jpg
 slug: se-podcast-26
@@ -50,4 +50,3 @@ No guest today. Moot had to postpone his appearance on the show. But David Fulle
 
 Jeff is off to the airport! Go see him at [_Ø_redev](http://oredev.org/2011)! We'll be back next week at the normal time (Tuesday @ 4pm ET) when [Dave Winer](http://dave.scripting.com/) (the Podfather) will be live in the studio with us.  [See you then](http://s.tk/livestream)!
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/27577920&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-11-16-se-podcast-27-dave-winer.markdown
+++ b/_posts/2011-11-16-se-podcast-27-dave-winer.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-11-16 20:00:20+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/11/se-podcast-27-dave-winer
 hero: /images/category/podcasts.jpg
 slug: se-podcast-27-dave-winer
@@ -55,4 +55,3 @@ Jeff & Joel are joined today by Dave Winer, who's upset that we don't have a jin
   * You can find Dave at [Scripting News](http://www.scripting.com), and you should also check out [EC2 for Poets](http://poets.scripting.com/).
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/28160568&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-11-23-se-podcast-28-brent-ozar.markdown
+++ b/_posts/2011-11-23-se-podcast-28-brent-ozar.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-11-23 20:00:33+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/11/se-podcast-28-brent-ozar
 hero: /images/category/podcasts.jpg
 slug: se-podcast-28-brent-ozar
@@ -49,4 +49,4 @@ Jeff & Joel are joined this week by Brent Ozar, database wizard who has helped t
   * You can find Brent at [his website](http://brentozar.com/) or [on Twitter](https://twitter.com/brento)! (Here's his [video](http://www.brentozar.com/archive/2011/11/how-stackoverflow-scales-sql-server-video/) about how Stack Overflow scales with SQL Server.)
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/28804935&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2011-11-30-se-podcast-29-chris-poole.markdown
+++ b/_posts/2011-11-30-se-podcast-29-chris-poole.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-11-30 20:00:16+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/11/se-podcast-29-chris-poole
 hero: /images/category/podcasts.jpg
 slug: se-podcast-29-chris-poole
@@ -70,4 +70,3 @@ Jeff and Joel are joined today by [Chris "Moot" Poole](http://www.twitter.com/mo
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/29369082&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>

--- a/_posts/2011-12-08-se-podcast-30-robert-cartaino-rebecca-chernoff.markdown
+++ b/_posts/2011-12-08-se-podcast-30-robert-cartaino-rebecca-chernoff.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2011-12-08 19:00:57+00:00
-layout: post
+layout: podcast
 redirect_from: /2011/12/se-podcast-30-robert-cartaino-rebecca-chernoff
 hero: /images/category/podcasts.jpg
 slug: se-podcast-30-robert-cartaino-rebecca-chernoff
@@ -51,4 +51,4 @@ Guests this week are [Robert Cartaino](http://stackexchange.com/users/34933/robe
 
 That's it for Podcast #30, which is it for podcasts in 2011. See you next year!
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/30073425&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2012-03-01-se-podcast-31-goodbye-jeff.markdown
+++ b/_posts/2012-03-01-se-podcast-31-goodbye-jeff.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2012-03-01 15:11:20+00:00
-layout: post
+layout: podcast
 redirect_from: /2012/03/se-podcast-31-goodbye-jeff
 hero: /images/category/podcasts.jpg
 slug: se-podcast-31-goodbye-jeff
@@ -75,4 +75,4 @@ Well, it's time for the final Stack Exchange Podcast featuring Jeff Atwood befor
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/38285361&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2012-03-06-se-podcast-32-jarrod-dixon-and-josh-heyer.markdown
+++ b/_posts/2012-03-06-se-podcast-32-jarrod-dixon-and-josh-heyer.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2012-03-06 15:15:27+00:00
-layout: post
+layout: podcast
 redirect_from: /2012/03/se-podcast-32-jarrod-dixon-and-josh-heyer
 hero: /images/category/podcasts.jpg
 slug: se-podcast-32-jarrod-dixon-and-josh-heyer
@@ -104,4 +104,4 @@ Well that's it for this week's podcast - join us in the coming weeks as we get b
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/38889143&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2012-10-15-se-podcast-33-its-back.markdown
+++ b/_posts/2012-10-15-se-podcast-33-its-back.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2012-10-15 18:29:08+00:00
-layout: post
+layout: podcast
 redirect_from: /2012/10/se-podcast-33-its-back
 hero: /images/category/podcasts.jpg
 slug: se-podcast-33-its-back
@@ -88,4 +88,4 @@ It's Back! Welcome to episode #33 of the Stack Exchange podcast.  We've got a b
 We'll see you next week!
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/63521866&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2012-10-23-se-podcast-34.markdown
+++ b/_posts/2012-10-23-se-podcast-34.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2012-10-23 14:15:15+00:00
-layout: post
+layout: podcast
 redirect_from: /2012/10/se-podcast-34
 hero: /images/category/podcasts.jpg
 slug: se-podcast-34
@@ -61,4 +61,4 @@ On the show this week are Kyle Brandt and Nick Craver, two SE employees who are 
 Tune in next week when we'll have Scott Hanselman on (for real this time)!
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/64405575&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2012-10-29-se-podcast-35-a-biscuit-away-from-jerry-stiller.markdown
+++ b/_posts/2012-10-29-se-podcast-35-a-biscuit-away-from-jerry-stiller.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2012-10-29 15:22:49+00:00
-layout: post
+layout: podcast
 redirect_from: /2012/10/se-podcast-35-a-biscuit-away-from-jerry-stiller
 hero: /images/category/podcasts.jpg
 slug: se-podcast-35-a-biscuit-away-from-jerry-stiller
@@ -74,4 +74,4 @@ Welcome to Stack Exchange podcast #35 with special guest Scott Hanselman. We als
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/65220816&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2012-11-09-se-podcast-36-we-got-hit-by-a-hurricane.markdown
+++ b/_posts/2012-11-09-se-podcast-36-we-got-hit-by-a-hurricane.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2012-11-09 17:07:58+00:00
-layout: post
+layout: podcast
 redirect_from: /2012/11/se-podcast-36-we-got-hit-by-a-hurricane
 hero: /images/category/podcasts.jpg
 slug: se-podcast-36-we-got-hit-by-a-hurricane
@@ -135,4 +135,4 @@ We're planning on telling the whole story of Hurricane Sandy - it's roughly in c
   
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/66762703&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2012-11-20-se-podcast-37.markdown
+++ b/_posts/2012-11-20-se-podcast-37.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2012-11-20 17:36:29+00:00
-layout: post
+layout: podcast
 redirect_from: /2012/11/se-podcast-37
 hero: /images/category/podcasts.jpg
 slug: se-podcast-37
@@ -61,4 +61,4 @@ Welcome back!  We're actually back to a fairly normal podcast this week and wan
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/68172637&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2012-12-03-se-podcast-38-this-ones-at-least-a-410.markdown
+++ b/_posts/2012-12-03-se-podcast-38-this-ones-at-least-a-410.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2012-12-03 15:29:37+00:00
-layout: post
+layout: podcast
 redirect_from: /2012/12/se-podcast-38-this-ones-at-least-a-410
 hero: /images/category/podcasts.jpg
 slug: se-podcast-38-this-ones-at-least-a-410
@@ -66,4 +66,4 @@ Welcome to Stack Exchange podcast #38 with Joel, Jay, David, and new special gue
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/69812124&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2012-12-24-podcast-39-the-one-with-wil-wheaton.markdown
+++ b/_posts/2012-12-24-podcast-39-the-one-with-wil-wheaton.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2012-12-24 15:34:05+00:00
-layout: post
+layout: podcast
 redirect_from: /2012/12/podcast-39-the-one-with-wil-wheaton
 hero: /images/category/podcasts.jpg
 slug: podcast-39-the-one-with-wil-wheaton
@@ -76,4 +76,4 @@ Today's guest is [Jeremy Tunnell](http://stackexchange.com/users/1635441/jeremy
 That's all for this week. See you on ChaCha!
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/72432544&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2013-01-10-podcast-40-2.markdown
+++ b/_posts/2013-01-10-podcast-40-2.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2013-01-10 16:15:18+00:00
-layout: post
+layout: podcast
 redirect_from: /2013/01/podcast-40-2
 hero: /images/category/podcasts.jpg
 slug: podcast-40-2
@@ -70,4 +70,4 @@ For you people listening at home: We want to take your questions! Go to [s.tk/p
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/74385052&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2013-01-28-podcast-41-neither-of-us-have-muscles.markdown
+++ b/_posts/2013-01-28-podcast-41-neither-of-us-have-muscles.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2013-01-28 18:33:01+00:00
-layout: post
+layout: podcast
 redirect_from: /2013/01/podcast-41-neither-of-us-have-muscles
 hero: /images/category/podcasts.jpg
 slug: podcast-41-neither-of-us-have-muscles
@@ -67,4 +67,4 @@ Welcome to Stack Exchange Podcast #41, featuring Joel Spolsky, Jay Hanlon, David
 We'll see you next week for another exciting episode of..... The Stack Exchange Podcast!
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/76831203&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2013-02-05-podcast-42-2.markdown
+++ b/_posts/2013-02-05-podcast-42-2.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2013-02-05 19:45:51+00:00
-layout: post
+layout: podcast
 redirect_from: /2013/02/podcast-42-2
 hero: /images/category/podcasts.jpg
 slug: podcast-42-2
@@ -72,4 +72,4 @@ Well that's the podcast for this week! Thanks for tuning in, and now for our st
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/77975208&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2013-02-21-podcast-43-false-facts-blood-feuds.markdown
+++ b/_posts/2013-02-21-podcast-43-false-facts-blood-feuds.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2013-02-21 18:31:19+00:00
-layout: post
+layout: podcast
 redirect_from: /2013/02/podcast-43-false-facts-blood-feuds
 hero: /images/category/podcasts.jpg
 slug: podcast-43-false-facts-blood-feuds
@@ -52,4 +52,4 @@ See you next week!
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/80236224&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2013-03-06-podcast-44-this-should-have-been-43.markdown
+++ b/_posts/2013-03-06-podcast-44-this-should-have-been-43.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2013-03-06 19:51:14+00:00
-layout: post
+layout: podcast
 redirect_from: /2013/03/podcast-44-this-should-have-been-43
 hero: /images/category/podcasts.jpg
 slug: podcast-44-this-should-have-been-43
@@ -60,4 +60,4 @@ Welcome Back!  Our guest today is the one and only Robert Scoble - blogger and 
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/82092950&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2013-03-18-podcast-45-keeping-it-sharp.markdown
+++ b/_posts/2013-03-18-podcast-45-keeping-it-sharp.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2013-03-18 23:30:26+00:00
-layout: post
+layout: podcast
 redirect_from: /2013/03/podcast-45-keeping-it-sharp
 hero: /images/category/podcasts.jpg
 slug: podcast-45-keeping-it-sharp
@@ -58,4 +58,4 @@ Our guest this week is Eric Lippert - language architect extraordinaire and famo
 Join us next week!
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/83835972&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2013-03-27-podcast-46-the-podcast-that-sounds-dirty-but-isnt.markdown
+++ b/_posts/2013-03-27-podcast-46-the-podcast-that-sounds-dirty-but-isnt.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2013-03-27 21:14:59+00:00
-layout: post
+layout: podcast
 redirect_from: /2013/03/podcast-46-the-podcast-that-sounds-dirty-but-isnt
 hero: /images/category/podcasts.jpg
 slug: podcast-46-the-podcast-that-sounds-dirty-but-isnt
@@ -67,4 +67,4 @@ That's a wrap! You've been listening to Stack Exchange Podcast #46 with special 
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/85215663&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2013-05-14-podcast-47-do-you-even-twitter-bro.markdown
+++ b/_posts/2013-05-14-podcast-47-do-you-even-twitter-bro.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2013-05-14 21:42:45+00:00
-layout: post
+layout: podcast
 redirect_from: /2013/05/podcast-47-do-you-even-twitter-bro
 hero: /images/wordpress/Screen-Shot-2013-05-14-at-4.40.15-PM-1024x577.jpg
 slug: podcast-47-do-you-even-twitter-bro
@@ -64,4 +64,4 @@ Taping podcasts in our new "studio"!
 That's our show! Thanks for listening to Stack Exchange Podcast #47. See you in two weeks!
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/92213289&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2013-06-03-podcast-48-sponsored-by-powdermilk-biscuits.markdown
+++ b/_posts/2013-06-03-podcast-48-sponsored-by-powdermilk-biscuits.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2013-06-03 14:58:12+00:00
-layout: post
+layout: podcast
 redirect_from: /2013/06/podcast-48-sponsored-by-powdermilk-biscuits
 hero: /images/category/podcasts.jpg
 slug: podcast-48-sponsored-by-powdermilk-biscuits
@@ -73,4 +73,4 @@ Thanks to [Jorge Castro](http://jorgecastro.org/) and Robert Cartaino for join
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/95226481&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2013-06-11-podcast-49-the-one-where-we-edited-out-the-title-reference.markdown
+++ b/_posts/2013-06-11-podcast-49-the-one-where-we-edited-out-the-title-reference.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2013-06-11 11:51:03+00:00
-layout: post
+layout: podcast
 redirect_from: /2013/06/podcast-49-the-one-where-we-edited-out-the-title-reference
 hero: /images/category/podcasts.jpg
 slug: podcast-49-the-one-where-we-edited-out-the-title-reference
@@ -58,4 +58,4 @@ Welcome to episode 49 of the Stack Exchange Podcast! We are welcoming special gu
 Thanks for listening to the Stack Exchange podcast, and thanks to our guest Matt Grum and his band [Juno](http://wearejuno.com/) for the outro music!
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/96395024&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2013-07-25-podcast-50-listen-to-this-podcast.markdown
+++ b/_posts/2013-07-25-podcast-50-listen-to-this-podcast.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2013-07-25 08:05:01+00:00
-layout: post
+layout: podcast
 redirect_from: /2013/07/podcast-50-listen-to-this-podcast
 hero: http://i.imgur.com/CqsAzHL.jpg
 slug: podcast-50-listen-to-this-podcast
@@ -73,4 +73,4 @@ Welcome to Stack Exchange podcast #50, featuring usual suspects Joel Spolsky, Ja
 Thanks for joining us!  Today's guest has been Nine Shogs Shogging, joining Jay Hanlon, David Fullerton, and Joel Spolsky.  Today's episode was sponsored by the House of Lords. See you next time!
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/102518231&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2013-08-05-podcast-51-the-return-of-codinghorror.markdown
+++ b/_posts/2013-08-05-podcast-51-the-return-of-codinghorror.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2013-08-05 14:01:14+00:00
-layout: post
+layout: podcast
 redirect_from: /2013/08/podcast-51-the-return-of-codinghorror
 hero: /images/category/podcasts.jpg
 slug: podcast-51-the-return-of-codinghorror
@@ -61,4 +61,4 @@ Welcome to Stack Exchange Podcast #51, with special guest [Jeff Atwood](http://
 Thanks for listening to the Stack Exchange podcast featuring Jeff Atwood! Check out [BoingBoing's forums](http://bbs.boingboing.net/) or [How-To Geek's forums](http://discuss.howtogeek.com/) to see [Discourse](http://www.discourse.org/) in action. Until next time!
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/104100512&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2013-09-03-podcast-52-we-didnt-need-headphones.markdown
+++ b/_posts/2013-09-03-podcast-52-we-didnt-need-headphones.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2013-09-03 19:34:45+00:00
-layout: post
+layout: podcast
 redirect_from: /2013/09/podcast-52-we-didnt-need-headphones
 hero: /images/category/podcasts.jpg
 slug: podcast-52-we-didnt-need-headphones
@@ -73,4 +73,4 @@ Welcome to Stack Exchange Podcast #52 with your hosts Joel Spolsky, David Fuller
 Thanks for listening to Stack Exchange Podcast #52. Marmite may be stored at room temperature, even after it's been opened.
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/108681379&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2013-10-28-podcast-53-lets-go-rio.markdown
+++ b/_posts/2013-10-28-podcast-53-lets-go-rio.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2013-10-28 18:20:25+00:00
-layout: post
+layout: podcast
 redirect_from: /2013/10/podcast-53-lets-go-rio
 hero: /images/category/podcasts.jpg
 slug: podcast-53-lets-go-rio
@@ -82,4 +82,4 @@ Thanks for listening to Stack Exchange Podcast #53 with special guest Gabe Kosck
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/117482173&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2013-11-14-podcast-54-the-one-with-all-the-anachronisms.markdown
+++ b/_posts/2013-11-14-podcast-54-the-one-with-all-the-anachronisms.markdown
@@ -2,7 +2,7 @@
 author: alex
 comments: true
 date: 2013-11-14 14:07:30+00:00
-layout: post
+layout: podcast
 redirect_from: /2013/11/podcast-54-the-one-with-all-the-anachronisms
 hero: /images/category/podcasts.jpg
 slug: podcast-54-the-one-with-all-the-anachronisms
@@ -91,4 +91,4 @@ Welcome to Stack Exchange Podcast #54, with special guest [Sara J. Chipps](http
 Thanks for listening to the Stack Exchange Podcast with special guest [Sara J. Chipps](https://twitter.com/sarajchipps), along with Stack Exchange CFO Michael Pryor, brought to you by [/r/husky](http://reddit.com/r/husky).
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/120103057&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2014-02-24-podcast-55-dont-call-it-a-comeback.markdown
+++ b/_posts/2014-02-24-podcast-55-dont-call-it-a-comeback.markdown
@@ -2,7 +2,7 @@
 author: hairboat
 comments: true
 date: 2014-02-24 20:00:27+00:00
-layout: post
+layout: podcast
 redirect_from: /2014/02/podcast-55-dont-call-it-a-comeback
 hero: /images/category/podcasts.jpg
 slug: podcast-55-dont-call-it-a-comeback
@@ -74,4 +74,4 @@ Thanks for joining us for Stack Exchange Podcast #55, sponsored by the city of S
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/135361168&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2014-03-17-podcast-56-green-or-red-curae.markdown
+++ b/_posts/2014-03-17-podcast-56-green-or-red-curae.markdown
@@ -2,7 +2,7 @@
 author: hairboat
 comments: true
 date: 2014-03-17 19:00:39+00:00
-layout: post
+layout: podcast
 redirect_from: /2014/03/podcast-56-green-or-red-curae
 hero: /images/category/podcasts.jpg
 slug: podcast-56-green-or-red-curae
@@ -80,4 +80,4 @@ Thanks for listening to Stack Exchange Podcast #56, sponsored by the Patent Trol
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/139449126&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2014-04-24-podcast-57-we-just-saw-this-on-florp.markdown
+++ b/_posts/2014-04-24-podcast-57-we-just-saw-this-on-florp.markdown
@@ -2,7 +2,7 @@
 author: hairboat
 comments: true
 date: 2014-04-24 19:00:10+00:00
-layout: post
+layout: podcast
 redirect_from: /2014/04/podcast-57-we-just-saw-this-on-florp
 hero: https://cloud.githubusercontent.com/assets/12239801/7544406/cc4004aa-f59a-11e4-8fdb-fd95d79b58c5.jpg
 slug: podcast-57-we-just-saw-this-on-florp
@@ -86,5 +86,5 @@ Thanks for joining us during this very productive hour of your life for Stack Ex
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/145239238&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+
 

--- a/_posts/2014-05-19-podcast-58-pack-em-in-like-bees.markdown
+++ b/_posts/2014-05-19-podcast-58-pack-em-in-like-bees.markdown
@@ -2,7 +2,7 @@
 author: hairboat
 comments: true
 date: 2014-05-19 19:00:11+00:00
-layout: post
+layout: podcast
 redirect_from: /2014/05/podcast-58-pack-em-in-like-bees
 hero: https://cloud.githubusercontent.com/assets/12239801/7544340/1bd31b20-f59a-11e4-8b75-3b3150f15671.JPG
 slug: podcast-58-pack-em-in-like-bees
@@ -96,5 +96,5 @@ Thanks for listening to Stack Exchange Podcast #58, brought to you by our iOS ap
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/149558524&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+
 

--- a/_posts/2014-05-29-podcast-59-hes-one-of-those-science-ists.markdown
+++ b/_posts/2014-05-29-podcast-59-hes-one-of-those-science-ists.markdown
@@ -2,7 +2,7 @@
 author: hairboat
 comments: true
 date: 2014-05-29 19:00:29+00:00
-layout: post
+layout: podcast
 redirect_from: /2014/05/podcast-59-hes-one-of-those-science-ists
 hero: /images/category/podcasts.jpg
 slug: podcast-59-hes-one-of-those-science-ists
@@ -62,4 +62,4 @@ Thanks for listening to Stack Exchange Podcast #59, brought to you by Nutella!
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/151731070&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2014-07-16-podcast-60-are-we-that-predictable.markdown
+++ b/_posts/2014-07-16-podcast-60-are-we-that-predictable.markdown
@@ -2,7 +2,7 @@
 author: hairboat
 comments: true
 date: 2014-07-16 19:00:44+00:00
-layout: post
+layout: podcast
 redirect_from: /2014/07/podcast-60-are-we-that-predictable
 hero: https://cloud.githubusercontent.com/assets/12239801/7544421/ee57b6aa-f59a-11e4-8d24-4cf85b5646a9.jpg
 slug: podcast-60-are-we-that-predictable
@@ -103,5 +103,5 @@ Thanks for listening to Stack Exchange Podcast #60, brought to you by the Nation
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/158893545&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+
 

--- a/_posts/2014-11-25-podcast-61-the-what-jays-done-wrong-podcast.markdown
+++ b/_posts/2014-11-25-podcast-61-the-what-jays-done-wrong-podcast.markdown
@@ -2,7 +2,7 @@
 author: hairboat
 comments: true
 date: 2014-11-25 19:37:42+00:00
-layout: post
+layout: podcast
 redirect_from: /2014/11/podcast-61-the-what-jays-done-wrong-podcast
 hero: https://cloud.githubusercontent.com/assets/12239801/7544037/84f1dde2-f597-11e4-81e0-4584a5ba2a93.jpg
 slug: podcast-61-the-what-jays-done-wrong-podcast
@@ -110,5 +110,5 @@ We've been going for HOURS (one hour), so it's time to wrap it up. Thanks for li
 
 
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/178619053&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+
 

--- a/_posts/2015-02-04-podcast-62-delete-this-whole-episode.markdown
+++ b/_posts/2015-02-04-podcast-62-delete-this-whole-episode.markdown
@@ -2,7 +2,7 @@
 author: hairboat
 comments: true
 date: 2015-02-04 20:00:01+00:00
-layout: post
+layout: podcast
 redirect_from: /2015/02/podcast-62-delete-this-whole-episode
 hero: https://cloud.githubusercontent.com/assets/12239801/7543865/08aaa008-f596-11e4-826a-253eb2ec0284.jpg
 slug: podcast-62-delete-this-whole-episode
@@ -97,5 +97,5 @@ Joel wants to sign off, but first make sure you check out [Expression Engine SE
 
 Thanks for wasting an hour on the Stack Exchange Podcast Episode #62, brought to you by the American Venture Capital Association.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/189301069&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+
 

--- a/_posts/2015-03-25-podcast-63-the-plumbers-up-to-67-coins.markdown
+++ b/_posts/2015-03-25-podcast-63-the-plumbers-up-to-67-coins.markdown
@@ -2,7 +2,7 @@
 author: hairboat
 comments: true
 date: 2015-03-25 20:00:01+00:00
-layout: post
+layout: podcast
 redirect_from: /2015/03/podcast-63-the-plumbers-up-to-67-coins/
 hero: https://cloud.githubusercontent.com/assets/12239801/7543823/a30079b2-f595-11e4-8463-c9f25dcfda81.jpg
 slug: podcast-63-the-plumbers-up-to-67-coins
@@ -36,5 +36,5 @@ So what came out of this discussion? [We changed close vote aging](http://meta.s
 
 Thanks for listening to the Stack Exchange Podcast, brought to you by Cool Whip -- a whipped topping, NOT whipped cream.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/197512699&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+
 

--- a/_posts/2015-05-11-stack-exchange-podcast-64-diverse-hiring-and-a-cat-named-alan-turing.markdown
+++ b/_posts/2015-05-11-stack-exchange-podcast-64-diverse-hiring-and-a-cat-named-alan-turing.markdown
@@ -2,7 +2,7 @@
 author: hairboat
 comments: true
 date: 2015-05-11 20:00:01+00:00
-layout: post
+layout: podcast
 redirect_from: /2015/05/stack-exchange-podcast-64-not-recorded-in-ithaca/
 hero: https://i.stack.imgur.com/FCLQG.jpg
 slug: podcast-64-diverse-hiring-and-a-cat-named-alan-turing
@@ -53,4 +53,4 @@ So what can we get better at? We put Roberta on the spot but she'd rather talk a
 
 Thanks for listening to Stack Exchange Podcast #64, brought to you by string cheese. See you next time!
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/204221383&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+

--- a/_posts/2015-06-16-stack-exchange-podcast-65-the-word-has-two-meanings-you-see.markdown
+++ b/_posts/2015-06-16-stack-exchange-podcast-65-the-word-has-two-meanings-you-see.markdown
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: podcast
 author: hairboat
 title: "Podcast #65 - The Word Has Two Meanings, You See"
 tags:
@@ -41,5 +41,5 @@ It’s finally time for…
 
 Thanks for listening to Stack Exchange Podcast Episode #65. For a special treat stay tuned after the credits for the Very First Episode of the Stack Overflow Podcast, starring Joel and co-founder (emeritus) Jeff Atwood.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/210303965&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+
 

--- a/_posts/2015-08-03-stack-exchange-podcast-66-thank-you-for-saying-words-to-us.markdown
+++ b/_posts/2015-08-03-stack-exchange-podcast-66-thank-you-for-saying-words-to-us.markdown
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: podcast
 date: 2015-08-03
 title: "Podcast #66 - Thank You For Saying Words To Us"
 author: hairboat
@@ -31,4 +31,4 @@ The biggest lesson we can take away is that we have to listen to the things our 
 
 We abruptly thank you for listening to Stack Exchange Podcast #66 brought to you by the AEFCSI!
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/214902705&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>
+


### PR DESCRIPTION
This PR converts all old podcast posts to use the 'podcast' layout. It adds subscribe links for iTunes and Google Play, along with a direct download link.

The change to the layout is quick and dirty to get this going. Easy to tweak and add some styling (and presumably the logos etc. at some point), since it's in one place.
