### PR TITLE
Revert titlecase change for podcast feed GUIDs and Disqus identifiers with future proofing

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -3,7 +3,7 @@
 	<div id="disqus_thread"></div>
 	<script>
 	    var disqus_shortname = '{{ site.disqus }}',
-	    	disqus_identifier = '{% if page.disqus_identifier %}{{ page.disqus_identifier}}{% else %}{{ site.url }}{{ page.url }}{% endif %}';
+	    	disqus_identifier = '{% if page.disqus_identifier %}{{ page.disqus_identifier}}{% else %}http://blog.stackoverflow.com{{ page.url | downcase }}{% endif %}';
 	    (function() {
 	        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
 	        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';

--- a/feed/podcast/index.xml
+++ b/feed/podcast/index.xml
@@ -71,7 +71,7 @@ Stack Overflow is the flagship property of a fast-growing network of over 100 qu
 			{% if post.wordpress_id %}
 			<guid isPermaLink="false">http://blog.stackoverflow.com/?p={{ post.wordpress_id }}</guid>
 			{% else %}
-			<guid isPermaLink="false">{{ site.url }}{{ post.url }}</guid>
+			<guid isPermaLink="false">http://blog.stackoverflow.com{{ post.url | downcase }}</guid>
 			{% endif %}
 			<description><![CDATA[{{ post.excerpt | raw }}]]></description>
 			<content:encoded><![CDATA[{{ post.content | raw }}]]></content:encoded>


### PR DESCRIPTION
@clipperhouse This is probably redundant since I believe you are reverting to lowercase everywhere, but it would future proof against other tweaks such as if there's a shift from http -> https.

Side effect: Disqus comments from live/production posts would be shown on dev. Could be a good thing?
